### PR TITLE
Play nice with multiple Python versions

### DIFF
--- a/wwrando.py
+++ b/wwrando.py
@@ -1,4 +1,4 @@
-
+#!/usr/bin/python3.4
 from PySide.QtGui import *
 from PySide.QtCore import *
 


### PR DESCRIPTION
I have Python 3.7 installed for the OOT Randomizer, and python apps are set to open with C:\Windows\pyw.exe. Trying to run wwrando.py just crashes because Python 3.7 is too new, but if you add this line to the beginning of the file it will find and use python 3.4 instead.