### PR TITLE
Update TotG Armos Knights 1

### DIFF
--- a/logic/item_locations.txt
+++ b/logic/item_locations.txt
@@ -925,7 +925,7 @@ Tower of the Gods - First Chest Guarded by Armos Knights:
     & Bombs
     & TotG Small Key x1
     & Can Defeat Yellow ChuChus
-    & Bombs
+    & Hero's Bow
   Original item: Joy Pendant
   Types: Dungeon
   Paths:


### PR DESCRIPTION
Previously had 2 bomb requirements and no bow requirements, which is required to get the platform moving up to where the door actually is