### PR TITLE
Support dual (2.x, 3.x) python installs and streamline dependency installing

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,3 @@
-
 py -3 -m PyInstaller wwrando.spec
+@if %errorlevel% neq 0 exit /b %errorlevel%
 py -3 build.py

--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,3 @@
 
-pyinstaller wwrando.spec
-
+py -3 -m PyInstaller wwrando.spec
 py -3 build.py

--- a/install_dependencies.bat
+++ b/install_dependencies.bat
@@ -1,0 +1,1 @@
+pip3 install -r requirements.txt

--- a/install_dependencies_for_exe_build.bat
+++ b/install_dependencies_for_exe_build.bat
@@ -1,0 +1,5 @@
+pip3 install pywin32-ctypes==0.1.2
+if %errorlevel% neq 0 exit /b %errorlevel%
+pip3 install PyInstaller
+if %errorlevel% neq 0 exit /b %errorlevel%
+install_dependencies.bat

--- a/install_dependencies_for_exe_build.bat
+++ b/install_dependencies_for_exe_build.bat
@@ -1,5 +1,5 @@
 pip3 install pywin32-ctypes==0.1.2
-if %errorlevel% neq 0 exit /b %errorlevel%
+@if %errorlevel% neq 0 exit /b %errorlevel%
 pip3 install PyInstaller
-if %errorlevel% neq 0 exit /b %errorlevel%
+@if %errorlevel% neq 0 exit /b %errorlevel%
 install_dependencies.bat


### PR DESCRIPTION
## What does this pull request change?
* Calling `build.bat` with python 2.x in your default path wants to run pyinstaller with python 2.x, this PR explicitly makes `build.bat` invoke with python 3.
* If `pyinstaller` fails, `build.py` will not run.
* Adds a set of batch files to streamline the installation of dependencies for Windows users. This allows bypassing the command prompt in the happy path if .py files are associated to run with Python 3.

## Testing
- [x] tested both new batch files and error checking from an environment with no packages installed other than pip and setuptools
- [x] tested build.bat changes with empty build environment, verified EXE ran

## Other thoughts
I could update `README.md` to use the batch files, but 2 of the batch files are now explicitly Windows flavored, while the readme currently spells out what you need regardless of platform. Alternatively, I could add .sh variants.