### PR TITLE
Allow groups to be placed as soon as they become useful

### DIFF
--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -161,9 +161,10 @@ def randomize_progression_items(self):
       should_place_useful_item = False
     
     # If we wind up placing a useful item it can be a single item or a group.
-    # But if we place an item that is not yet useful, we need to exclude groups.
+    # But if we place an item that is not yet useful, we need to exclude groups that are not useful.
     # This is so that a group doesn't wind up taking every single possible remaining location while not opening up new ones.
-    possible_items_when_not_placing_useful = [name for name in possible_items if name not in self.logic.progress_item_groups]
+    not_useful_groups = [name for name in self.logic.progress_item_groups if self.logic.get_first_useful_item([name], for_progression=True) is None]
+    possible_items_when_not_placing_useful = [name for name in possible_items if name not in not_useful_groups]
     # Only exception is when there's exclusively groups left to place. Then we allow groups even if they're not useful.
     if len(possible_items_when_not_placing_useful) == 0 and len(possible_items) > 0:
       possible_items_when_not_placing_useful = possible_items


### PR DESCRIPTION
Previously, a group could only be placed if there were fewer than 17 accessible locations and if the group was useful.

This was good for the Triforce Shards because it would mean that they would only get placed at the very end. However, since the number of accessible locations quickly goes above 16, it caused the pearls to not be placed until the end if they didn't become useful soon enough. The biggest consequence of the old behavior was that it made whichever dungeon was in the TotG sector contain very few useful items.

There might be a different way to write this code to make the performance a bit better. Checking the groups before placing each item requires a bit more time than before.