### PR TITLE
Improve distribution of progress items across locations

### DIFF
--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -127,6 +127,8 @@ def randomize_progression_items(self):
   
   # Place progress items.
   previously_accessible_undone_locations = []
+  location_weights = {}
+  current_weight = 1
   while self.logic.unplaced_progress_items:
     accessible_undone_locations = self.logic.get_accessible_remaining_locations(for_progression=True)
     
@@ -144,6 +146,13 @@ def randomize_progression_items(self):
         self.logic.set_location_to_item(dungeon_item_location_name, dungeon_item_name)
       
       continue # Redo this loop iteration with the dungeon item locations no longer being considered 'remaining'.
+
+    for location in accessible_undone_locations:
+      if location not in location_weights:
+        location_weights[location] = int(current_weight)
+      elif location_weights[location] > 1:
+        location_weights[location] -= 1;
+    current_weight += 1
     
     possible_items = self.logic.unplaced_progress_items
     
@@ -240,10 +249,7 @@ def randomize_progression_items(self):
       # This way there is still a good chance it will not choose a new location.
       possible_locations_with_weighting = []
       for location_name in possible_locations:
-        if location_name not in previously_accessible_undone_locations:
-          weight = 2
-        else:
-          weight = 1
+        weight = location_weights[location_name]
         possible_locations_with_weighting += [location_name]*weight
       
       location_name = self.rng.choice(possible_locations_with_weighting)

--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -149,7 +149,7 @@ def randomize_progression_items(self):
 
     for location in accessible_undone_locations:
       if location not in location_weights:
-        location_weights[location] = int(current_weight)
+        location_weights[location] = current_weight
       elif location_weights[location] > 1:
         location_weights[location] -= 1;
     current_weight += 1


### PR DESCRIPTION
The current code gives double weight to locations when they have just become accessible. However, locations that are accessible early get many more chances to have an item, and the distribution of items is very heavily skewed towards locations that are accessible early. These changes mitigate that to some extent, distributing the items much more evenly throughout the game.

Here is a comparison of the new distribution to the old one (using the tournament settings): https://docs.google.com/spreadsheets/d/1Pq2K9ID4Q6wCr4Pd1Vpf2Eus6YeBvBnm_zLgBrZqy_U/edit#gid=1586599983

One potential concern might be the length of a playthrough with these changes. However, from personal experience, I think the difference would be marginal if anything. While items would generally be obtained slightly later, the total number of checks would not really change. Also, I think there's a huge benefit to having Earth Temple, Wind Temple, and Ganon's Tower not be empty as often.