### PR TITLE
Use HEAD instead of ORIG_HEAD to determine version

### DIFF
--- a/randomizer.py
+++ b/randomizer.py
@@ -34,7 +34,7 @@ VERSION_WITHOUT_COMMIT = VERSION
 try:
   from sys import _MEIPASS
 except ImportError:
-  git_commit_hash_file = os.path.join(RANDO_ROOT_PATH, ".git", "ORIG_HEAD")
+  git_commit_hash_file = os.path.join(RANDO_ROOT_PATH, ".git", "HEAD")
   if os.path.isfile(git_commit_hash_file):
     with open(git_commit_hash_file, "r") as f:
       VERSION += "_" + f.read()[:7]


### PR DESCRIPTION
`.git/HEAD` contains the SHA of the currently checked out commit. `.git/ORIG_HEAD` is the "previous state" of HEAD, and should not be used to determine the current version at runtime.

Now when checking out various revisions and running from source, the correct SHA should appear in the window title.