### PR TITLE
Fix Outset cave entrance not requiring Power Bracelets

### DIFF
--- a/logic/item_locations.txt
+++ b/logic/item_locations.txt
@@ -89,7 +89,6 @@ Outset Island - Dig up Black Soil:
 Outset Island - Savage Labyrinth - Floor 30:
   Need:
     Can Access Savage Labyrinth
-    & Power Bracelets
     & Can Defeat Keese
     & Can Defeat Miniblins
     & Can Defeat Red ChuChus

--- a/logic/macros.txt
+++ b/logic/macros.txt
@@ -106,8 +106,9 @@ Can Access Wind Temple:
   Can Access Dungeon Entrance On Gale Isle
 
 Can Access Secret Cave Entrance on Outset Island:
-  (Can Cut Down Outset Trees & Can Fly With Deku Leaf Outdoors)
-  | Hookshot
+  ((Can Cut Down Outset Trees & Can Fly With Deku Leaf Outdoors)
+  | Hookshot)
+  & Power Bracelets
 Can Access Secret Cave Entrance on Dragon Roost Island:
   Can Move Boulders
 Can Access Secret Cave Entrance on Fire Mountain:


### PR DESCRIPTION
Was reported in #bug-reports in the Wind Waker Randomizer Discord server.