### PR TITLE
Add more items to optional starting gear

### DIFF
--- a/wwr_ui/inventory.py
+++ b/wwr_ui/inventory.py
@@ -5,6 +5,7 @@ REGULAR_ITEMS = [
   "Telescope",
   "Magic Armor",
   "Hero's Charm",
+  "Tingle Tuner",
   "Grappling Hook",
   "Power Bracelets",
   "Iron Boots",
@@ -15,7 +16,13 @@ REGULAR_ITEMS = [
   "Deku Leaf",
   "Mirror Shield",
   "Hurricane Spin",
-]
+  "Din's Pearl",
+  "Farore's Pearl",
+  "Nayru's Pearl",
+  "Command Melody",
+  "Earth God's Lyric",
+  "Wind God's Aria",
+] + ["Empty Bottle"] * 4
 REGULAR_ITEMS.sort()
 
 PROGRESSIVE_ITEMS = \

--- a/wwr_ui/inventory.py
+++ b/wwr_ui/inventory.py
@@ -1,5 +1,5 @@
-# Can't use logic's PROGRESS_ITEMS because we don't want all items
-# to be accessible early and remove too much fun
+# Can't use logic's PROGRESS_ITEMS because there's some items
+# that we can't start with
 # And also because progressive items require special handling
 REGULAR_ITEMS = [
   "Telescope",

--- a/wwr_ui/inventory.py
+++ b/wwr_ui/inventory.py
@@ -30,7 +30,8 @@ PROGRESSIVE_ITEMS = \
     ["Progressive Quiver"]    * 2 + \
     ["Progressive Bomb Bag"]  * 2 + \
     ["Progressive Wallet"]    * 2 + \
-    ["Progressive Picto Box"] * 2
+    ["Progressive Picto Box"] * 2 + \
+    ["Progressive Sword"]     * 3
 PROGRESSIVE_ITEMS.sort()
 
 INVENTORY_ITEMS = REGULAR_ITEMS + PROGRESSIVE_ITEMS

--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -747,16 +747,19 @@ class WWRandomizerWindow(QMainWindow):
     sword_mode = self.get_option_value("sword_mode")
     if sword_mode == "Swordless":
       items_to_filter_out += ["Hurricane Spin"]
+    if sword_mode == "Swordless" or sword_mode == "Randomized Sword":
+      items_to_filter_out += 3 * ["Progressive Sword"]
     
     if self.get_option_value("race_mode"):
       num_possible_rewards = 8 - int(self.get_option_value("num_starting_triforce_shards"))
-      
+      potential_boss_rewards = []
+
       if sword_mode == "Start with Sword":
-        num_possible_rewards += 3
+        potential_boss_rewards += 3 * ["Progressive Sword"]
       elif sword_mode == "Randomized Sword":
         num_possible_rewards += 4
 
-      potential_boss_rewards = 3 * ["Progressive Bow"] + ["Hookshot"]
+      potential_boss_rewards += 3 * ["Progressive Bow"] + ["Hookshot"]
       while num_possible_rewards < 4:
         cur_reward = potential_boss_rewards.pop(0)
         items_to_filter_out += [cur_reward]


### PR DESCRIPTION
I wasn't able to add any of the bags or the Ghost Ship Chart without getting crashes, and the Magic Meter upgrade doesn't actually give you double magic, but the rest of the items seem to work.

For sword upgrades, we filter these out if you have Swordless or Randomized Sword mode on, or if race mode would place it as a dungeon reward.

#124 