### PR TITLE
Fix PyInstaller encryption

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,11 +1,9 @@
-set /p key= < keys/build_key.txt
-
-py -3.8-32 -m PyInstaller wwrando.spec --key=%key%
+py -3.8-32 -m PyInstaller wwrando.spec
 if %errorlevel% neq 0 exit /b %errorlevel%
 py -3.8-32 build.py
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-py -3.8 -m PyInstaller wwrando.spec --key=%key%
+py -3.8 -m PyInstaller wwrando.spec
 if %errorlevel% neq 0 exit /b %errorlevel%
 py -3.8 build.py
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -2,5 +2,6 @@ PySide2==5.15.0
 PyYAML==5.3.1
 Pillow==8.0.1
 PyInstaller==4.1
+tinyaes==1.0.1
 git+git://github.com/LagoLunatic/PyFastBTI.git@da01c14562a4711e031fd0a01c52d2131035e228#egg=PyFastBTI
 git+git://github.com/LagoLunatic/PyFastTextureUtils.git@8fd8558f710c537d852ae407a5b316ab8bbb2337#egg=PyFastTextureUtils

--- a/wwrando.spec
+++ b/wwrando.spec
@@ -1,6 +1,9 @@
 # -*- mode: python -*-
 
-block_cipher = None
+with open("./keys/build_key.txt") as f:
+  cipher_key = f.read().strip()
+
+block_cipher = pyi_crypto.PyiBlockCipher(key=cipher_key)
 
 with open("./version.txt") as f:
   randomizer_version = f.read().strip()


### PR DESCRIPTION
`--key` wasn't actually being used because this project uses `wwrando.spec` to provide options to PyInstaller. Instead, we can provide a cipher in `wwrando.spec`.

`tinyaes` is required for PyInstaller encryption.