### PR TITLE
Improve seed key generation

### DIFF
--- a/keys/generate_keys.bat
+++ b/keys/generate_keys.bat
@@ -1,6 +1,19 @@
-py -3.8 generate_key.py > temp_seed_key
-set /p seed_key= < temp_seed_key
-del temp_seed_key
-echo SEED_KEY="%seed_key%" > seed_key.py
+py -3.8 generate_key.py > temp_key
+set /p key_1= < temp_key
+del temp_key
+
+py -3.8 generate_key.py > temp_key
+set /p key_2= < temp_key
+del temp_key
+
+py -3.8 generate_key.py > temp_key
+set /p key_3= < temp_key
+del temp_key
+
+py -3.8 generate_key.py > temp_key
+set /p key_4= < temp_key
+del temp_key
+
+echo SEED_KEY=str(0X%key_1%-(0X%key_2%+0X%key_3%)/0X%key_4%) > seed_key.py
 
 py -3.8 generate_key.py > build_key.txt


### PR DESCRIPTION
Previously, it was really easy to extract the built PyInstaller executable and retrieve the seed key, since it was stored directly as a string in the `.pyc` file. These changes update the key generation script such that `seed_key.py` is significantly more complicated to reverse engineer.