### PR TITLE
Add an option to choose the number of required dungeons in Race Mode

### DIFF
--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -1,6 +1,7 @@
 
 import os
 import re
+from collections import OrderedDict
 
 from fs_helpers import *
 import tweaks
@@ -50,6 +51,13 @@ def randomize_items(self):
     self.logic.set_location_to_item(location_name, item_name)
 
 def randomize_boss_rewards(self):
+  # Try to generate dungeon boss reward locations until a valid set of locations is found.
+  for i in range(1, 50):
+    if try_randomize_boss_rewards(self):
+      return
+  raise Exception("Cannot randomize boss rewards! Please try randomizing with a different seed.")
+
+def try_randomize_boss_rewards(self):
   if not self.options.get("progression_dungeons"):
     raise Exception("Cannot randomize boss rewards when progress items are not allowed in dungeons.")
   
@@ -92,8 +100,6 @@ def randomize_boss_rewards(self):
       if item_name == "Progressive Bow"
     ]
     boss_reward_items += bow_upgrades[0:num_additional_rewards_needed]
-  
-  self.rng.shuffle(boss_reward_items)
 
   possible_additional_rewards = ["Hookshot", "Mirror Shield", "Boomerang"]
 
@@ -104,13 +110,41 @@ def randomize_boss_rewards(self):
       item_name for item_name in unplaced_progress_items_degrouped
       if item_name in possible_additional_rewards
     ]
-    self.rng.shuffle(additional_rewards)
-    # Need to make sure these items are at the start of the list since they're more picky about which bosses can drop them.
-    boss_reward_items = additional_rewards[0:num_additional_rewards_needed] + boss_reward_items
+    boss_reward_items += additional_rewards[0:num_additional_rewards_needed]
+
+  self.rng.shuffle(boss_reward_items)
 
   if len(boss_reward_items) != total_num_rewards:
     raise Exception("Number of boss reward items is incorrect: " + ", ".join(boss_reward_items))
   
+  possible_boss_locations = [
+    loc for loc in self.logic.remaining_item_locations
+    if self.logic.item_locations[loc]["Original item"] == "Heart Container"
+  ]
+  
+  if len(possible_boss_locations) != 6:
+    raise Exception("Number of boss item locations is incorrect: " + ", ".join(possible_boss_locations))
+
+  boss_reward_locations = OrderedDict()
+
+  # Decide what reward item to place in each boss location.
+  for item_name in boss_reward_items:    
+    if self.dungeons_only_start and "Dragon Roost Cavern - Gohma Heart Container" in possible_boss_locations:
+      location_name = "Dragon Roost Cavern - Gohma Heart Container"
+    elif self.dungeons_only_start and "Forbidden Woods - Kalle Demos Heart Container" in possible_boss_locations:
+      location_name = "Forbidden Woods - Kalle Demos Heart Container"
+    else:
+      location_name = self.rng.choice(possible_boss_locations)
+    possible_boss_locations.remove(location_name)
+    boss_reward_locations[location_name] = item_name
+
+  # Verify that the dungeon boss rewards were placed in a way that allows them all to be accessible.
+  locations_valid = validate_boss_reward_locations(self, boss_reward_locations)
+
+  # If the dungeon boss reward locations are not valid, a new set of dungeon boss reward locations will be generated.
+  if not locations_valid:
+    return False
+
   # Remove any Triforce Shards we're about to use from the progress item group, and add them as ungrouped progress items instead.
   for group_name, group_item_names in self.logic.progress_item_groups.items():
     items_to_remove_from_group = [
@@ -126,39 +160,8 @@ def randomize_boss_rewards(self):
     if len(self.logic.progress_item_groups[group_name]) == 0:
       if group_name in self.logic.unplaced_progress_items:
         self.logic.unplaced_progress_items.remove(group_name)
-  
-  possible_boss_locations = [
-    loc for loc in self.logic.remaining_item_locations
-    if self.logic.item_locations[loc]["Original item"] == "Heart Container"
-  ]
-  
-  if len(possible_boss_locations) != 6:
-    raise Exception("Number of boss item locations is incorrect: " + ", ".join(possible_boss_locations))
 
-  banned_additional_reward_locations = []
-  if "Hookshot" in boss_reward_items:
-    banned_additional_reward_locations.append("Wind Temple - Molgera Heart Container")
-  if "Mirror Shield" in boss_reward_items:
-    banned_additional_reward_locations.append("Earth Temple - Jalhalla Heart Container")
-  if "Boomerang" in boss_reward_items:
-    banned_additional_reward_locations.append("Forbidden Woods - Kalle Demos Heart Container")
-
-  # Decide what reward item to place in each boss location.
-  for item_name in boss_reward_items:
-    possible_boss_locations_for_this_item = possible_boss_locations.copy()
-    if item_name in possible_additional_rewards:
-      possible_boss_locations_for_this_item = [
-        loc for loc in possible_boss_locations_for_this_item
-        if loc not in banned_additional_reward_locations
-      ]
-    
-    if self.dungeons_only_start and "Dragon Roost Cavern - Gohma Heart Container" in possible_boss_locations_for_this_item:
-      location_name = "Dragon Roost Cavern - Gohma Heart Container"
-    elif self.dungeons_only_start and "Forbidden Woods - Kalle Demos Heart Container" in possible_boss_locations_for_this_item:
-      location_name = "Forbidden Woods - Kalle Demos Heart Container"
-    else:
-      location_name = self.rng.choice(possible_boss_locations_for_this_item)
-    possible_boss_locations.remove(location_name)
+  for location_name, item_name in boss_reward_locations.items():
     self.logic.set_prerandomization_item_location(location_name, item_name)
     self.race_mode_required_locations.append(location_name)
     
@@ -182,6 +185,62 @@ def randomize_boss_rewards(self):
       self.race_mode_banned_locations.append(location_name)
     elif location_name == "Mailbox - Letter from Tingle" and "Forsaken Fortress" in banned_dungeons:
       self.race_mode_banned_locations.append(location_name)
+
+  return True
+
+def validate_boss_reward_locations(self, boss_reward_locations):
+  boss_reward_items = list(boss_reward_locations.values())
+
+  # Temporarily own every item that is not a dungeon boss reward.
+  items_to_temporarily_add = self.logic.unplaced_progress_items + self.logic.unplaced_nonprogress_items
+  for item_name in boss_reward_items:
+    if item_name in items_to_temporarily_add:
+      items_to_temporarily_add.remove(item_name)
+
+  for item_name in items_to_temporarily_add:
+    self.logic.add_owned_item_or_item_group(item_name)
+
+  locations_valid = True
+  temporary_boss_reward_items = []
+  remaining_boss_reward_items = boss_reward_items
+  remaining_boss_locations = list(boss_reward_locations.keys())
+
+  while remaining_boss_reward_items:
+    # Consider a dungeon boss reward to be accessible when every location in the dungeon is accessible.
+    accessible_undone_locations = self.logic.get_accessible_remaining_locations()    
+    inaccessible_dungeons = []
+    for location_name in self.logic.remaining_item_locations:
+      if self.logic.is_dungeon_location(location_name) and location_name not in accessible_undone_locations:
+        dungeon_name, _ = self.logic.split_location_name_by_zone(location_name)
+        inaccessible_dungeons.append(dungeon_name)
+
+    accessible_boss_locations = []
+    for boss_location in remaining_boss_locations:
+      dungeon_name, _ = self.logic.split_location_name_by_zone(boss_location)
+
+      if dungeon_name not in inaccessible_dungeons:
+        accessible_boss_locations.append(boss_location)
+
+    # If there are no more accessible dungeon boss rewards, consider the dungeon boss locations to be invalid.
+    if not accessible_boss_locations:
+      locations_valid = False
+      break
+
+    # Temporarily own dungeon boss rewards that are now accessible.
+    for location_name in accessible_boss_locations:
+      item_name = boss_reward_locations[location_name]
+      self.logic.add_owned_item_or_item_group(item_name)
+      temporary_boss_reward_items.append(item_name)
+      remaining_boss_reward_items.remove(item_name)
+      remaining_boss_locations.remove(location_name)
+
+  # Remove temporarily owned items.
+  for item_name in items_to_temporarily_add:
+    self.logic.remove_owned_item_or_item_group(item_name)
+  for item_name in temporary_boss_reward_items:
+    self.logic.remove_owned_item_or_item_group(item_name)
+
+  return locations_valid
 
 def randomize_dungeon_items(self):
   # Places dungeon-specific items first so all the dungeon locations don't get used up by other items.
@@ -310,7 +369,7 @@ def randomize_progression_items(self):
       if location not in location_weights:
         location_weights[location] = current_weight
       elif location_weights[location] > 1:
-        location_weights[location] -= 1;
+        location_weights[location] -= 1
     current_weight += 1
     
     possible_items = self.logic.unplaced_progress_items.copy()

--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -215,20 +215,20 @@ def validate_boss_reward_locations(self, boss_reward_locations):
         dungeon_name, _ = self.logic.split_location_name_by_zone(location_name)
         inaccessible_dungeons.append(dungeon_name)
     
-    accessible_boss_locations = []
+    newly_accessible_boss_locations = []
     for boss_location in remaining_boss_locations:
       dungeon_name, _ = self.logic.split_location_name_by_zone(boss_location)
       
       if dungeon_name not in inaccessible_dungeons:
-        accessible_boss_locations.append(boss_location)
+        newly_accessible_boss_locations.append(boss_location)
     
     # If there are no more accessible dungeon boss rewards, consider the dungeon boss locations to be invalid.
-    if not accessible_boss_locations:
+    if not newly_accessible_boss_locations:
       locations_valid = False
       break
     
     # Temporarily own dungeon boss rewards that are now accessible.
-    for location_name in accessible_boss_locations:
+    for location_name in newly_accessible_boss_locations:
       item_name = boss_reward_locations[location_name]
       self.logic.add_owned_item_or_item_group(item_name)
       temporary_boss_reward_items.append(item_name)

--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -192,7 +192,8 @@ def validate_boss_reward_locations(self, boss_reward_locations):
   boss_reward_items = list(boss_reward_locations.values())
   
   # Temporarily own every item that is not a dungeon boss reward.
-  items_to_temporarily_add = self.logic.unplaced_progress_items + self.logic.unplaced_nonprogress_items
+  items_to_temporarily_add = self.logic.unplaced_progress_items.copy()
+  
   for item_name in boss_reward_items:
     if item_name in items_to_temporarily_add:
       items_to_temporarily_add.remove(item_name)

--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -100,9 +100,9 @@ def try_randomize_boss_rewards(self):
       if item_name == "Progressive Bow"
     ]
     boss_reward_items += bow_upgrades[0:num_additional_rewards_needed]
-
+  
   possible_additional_rewards = ["Hookshot", "Mirror Shield", "Boomerang"]
-
+  
   # If we STILL need more rewards, use the Hookshot, Mirror Shield, and Boomerang.
   num_additional_rewards_needed = total_num_rewards - len(boss_reward_items)
   if num_additional_rewards_needed > 0:
@@ -111,9 +111,9 @@ def try_randomize_boss_rewards(self):
       if item_name in possible_additional_rewards
     ]
     boss_reward_items += additional_rewards[0:num_additional_rewards_needed]
-
+  
   self.rng.shuffle(boss_reward_items)
-
+  
   if len(boss_reward_items) != total_num_rewards:
     raise Exception("Number of boss reward items is incorrect: " + ", ".join(boss_reward_items))
   
@@ -124,9 +124,9 @@ def try_randomize_boss_rewards(self):
   
   if len(possible_boss_locations) != 6:
     raise Exception("Number of boss item locations is incorrect: " + ", ".join(possible_boss_locations))
-
+  
   boss_reward_locations = OrderedDict()
-
+  
   # Decide what reward item to place in each boss location.
   for item_name in boss_reward_items:    
     if self.dungeons_only_start and "Dragon Roost Cavern - Gohma Heart Container" in possible_boss_locations:
@@ -137,14 +137,14 @@ def try_randomize_boss_rewards(self):
       location_name = self.rng.choice(possible_boss_locations)
     possible_boss_locations.remove(location_name)
     boss_reward_locations[location_name] = item_name
-
+  
   # Verify that the dungeon boss rewards were placed in a way that allows them all to be accessible.
   locations_valid = validate_boss_reward_locations(self, boss_reward_locations)
-
+  
   # If the dungeon boss reward locations are not valid, a new set of dungeon boss reward locations will be generated.
   if not locations_valid:
     return False
-
+  
   # Remove any Triforce Shards we're about to use from the progress item group, and add them as ungrouped progress items instead.
   for group_name, group_item_names in self.logic.progress_item_groups.items():
     items_to_remove_from_group = [
@@ -160,7 +160,7 @@ def try_randomize_boss_rewards(self):
     if len(self.logic.progress_item_groups[group_name]) == 0:
       if group_name in self.logic.unplaced_progress_items:
         self.logic.unplaced_progress_items.remove(group_name)
-
+  
   for location_name, item_name in boss_reward_locations.items():
     self.logic.set_prerandomization_item_location(location_name, item_name)
     self.race_mode_required_locations.append(location_name)
@@ -185,26 +185,26 @@ def try_randomize_boss_rewards(self):
       self.race_mode_banned_locations.append(location_name)
     elif location_name == "Mailbox - Letter from Tingle" and "Forsaken Fortress" in banned_dungeons:
       self.race_mode_banned_locations.append(location_name)
-
+  
   return True
 
 def validate_boss_reward_locations(self, boss_reward_locations):
   boss_reward_items = list(boss_reward_locations.values())
-
+  
   # Temporarily own every item that is not a dungeon boss reward.
   items_to_temporarily_add = self.logic.unplaced_progress_items + self.logic.unplaced_nonprogress_items
   for item_name in boss_reward_items:
     if item_name in items_to_temporarily_add:
       items_to_temporarily_add.remove(item_name)
-
+  
   for item_name in items_to_temporarily_add:
     self.logic.add_owned_item_or_item_group(item_name)
-
+  
   locations_valid = True
   temporary_boss_reward_items = []
   remaining_boss_reward_items = boss_reward_items
   remaining_boss_locations = list(boss_reward_locations.keys())
-
+  
   while remaining_boss_reward_items:
     # Consider a dungeon boss reward to be accessible when every location in the dungeon is accessible.
     accessible_undone_locations = self.logic.get_accessible_remaining_locations()    
@@ -213,19 +213,19 @@ def validate_boss_reward_locations(self, boss_reward_locations):
       if self.logic.is_dungeon_location(location_name) and location_name not in accessible_undone_locations:
         dungeon_name, _ = self.logic.split_location_name_by_zone(location_name)
         inaccessible_dungeons.append(dungeon_name)
-
+    
     accessible_boss_locations = []
     for boss_location in remaining_boss_locations:
       dungeon_name, _ = self.logic.split_location_name_by_zone(boss_location)
-
+      
       if dungeon_name not in inaccessible_dungeons:
         accessible_boss_locations.append(boss_location)
-
+    
     # If there are no more accessible dungeon boss rewards, consider the dungeon boss locations to be invalid.
     if not accessible_boss_locations:
       locations_valid = False
       break
-
+    
     # Temporarily own dungeon boss rewards that are now accessible.
     for location_name in accessible_boss_locations:
       item_name = boss_reward_locations[location_name]
@@ -233,13 +233,13 @@ def validate_boss_reward_locations(self, boss_reward_locations):
       temporary_boss_reward_items.append(item_name)
       remaining_boss_reward_items.remove(item_name)
       remaining_boss_locations.remove(location_name)
-
+  
   # Remove temporarily owned items.
   for item_name in items_to_temporarily_add:
     self.logic.remove_owned_item_or_item_group(item_name)
   for item_name in temporary_boss_reward_items:
     self.logic.remove_owned_item_or_item_group(item_name)
-
+  
   return locations_valid
 
 def randomize_dungeon_items(self):

--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -202,7 +202,7 @@ def validate_boss_reward_locations(self, boss_reward_locations):
   
   locations_valid = True
   temporary_boss_reward_items = []
-  remaining_boss_reward_items = boss_reward_items
+  remaining_boss_reward_items = boss_reward_items.copy()
   remaining_boss_locations = list(boss_reward_locations.keys())
   
   while remaining_boss_reward_items:

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -148,11 +148,11 @@ OPTIONS = OrderedDict([
   ),
   (
     "race_mode",
-    "In Race Mode, required dungeon bosses will drop required items (e.g. Triforce Shards). Nothing in the other dungeons will ever be required.\nYou can see which islands have the required dungeons on them by opening the sea chart and checking which islands have blue quest markers.",
+    "In Race Mode, certain randomly chosen dungeon bosses will drop required items (e.g. Triforce Shards). Nothing in the other dungeons will ever be required.\nYou can see which islands have the required dungeons on them by opening the sea chart and checking which islands have blue quest markers.",
   ),
   (
     "num_race_mode_dungeons",
-    "Choose the number of dungeons that are required in Race Mode.\nRequired dungeon bosses will drop required items (e.g. Triforce Shards). Nothing in the other dungeons will ever be required.",
+    "Select the number of dungeons that are required in Race Mode.\nRequired dungeon bosses will drop required items (e.g. Triforce Shards). Nothing in the other dungeons will ever be required.",
   ),
   (
     "randomize_music",

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -148,7 +148,11 @@ OPTIONS = OrderedDict([
   ),
   (
     "race_mode",
-    "In Race Mode, 4 random dungeon bosses will drop required items (e.g. Triforce Shards). Nothing in the other 2 dungeons will ever be required.\nYou can see which islands have the required dungeons on them by opening the sea chart and checking which islands have blue quest markers.",
+    "In Race Mode, required dungeon bosses will drop required items (e.g. Triforce Shards). Nothing in the other dungeons will ever be required.\nYou can see which islands have the required dungeons on them by opening the sea chart and checking which islands have blue quest markers.",
+  ),
+  (
+    "num_race_mode_dungeons",
+    "Choose the number of dungeons that are required in Race Mode.\nRequired dungeon bosses will drop required items (e.g. Triforce Shards). Nothing in the other dungeons will ever be required.",
   ),
   (
     "randomize_music",

--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -951,11 +951,13 @@ class WWRandomizerWindow(QMainWindow):
       elif sword_mode == "No Starting Sword":
         num_possible_rewards += 4
       
-      potential_boss_rewards += 3 * ["Progressive Bow"] + ["Hookshot"]
-      while num_possible_rewards < 4:
+      potential_boss_rewards += 3 * ["Progressive Bow"] + ["Hookshot", "Mirror Shield", "Boomerang"]
+      while num_possible_rewards < int(self.get_option_value("num_race_mode_dungeons")):
         cur_reward = potential_boss_rewards.pop(0)
         items_to_filter_out += [cur_reward]
         num_possible_rewards += 1
+    else:
+      should_enable_options["num_race_mode_dungeons"] = False
     
     self.filtered_rgear.setFilterStrings(items_to_filter_out)
     
@@ -985,7 +987,8 @@ class WWRandomizerWindow(QMainWindow):
         widget.setEnabled(True)
       else:
         widget.setEnabled(False)
-        widget.setChecked(False)
+        if isinstance(widget, QAbstractButton):
+          widget.setChecked(False)
     
     # Disable options that produce unbeatable seeds when not running from source.
     if not IS_RUNNING_FROM_SOURCE:

--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -983,12 +983,17 @@ class WWRandomizerWindow(QMainWindow):
     
     for option_name in OPTIONS:
       widget = getattr(self.ui, option_name)
+      label_for_option = getattr(self.ui, "label_for_" + option_name, None)
       if should_enable_options[option_name]:
         widget.setEnabled(True)
+        if label_for_option:
+          label_for_option.setEnabled(True)
       else:
         widget.setEnabled(False)
         if isinstance(widget, QAbstractButton):
           widget.setChecked(False)
+        if label_for_option:
+          label_for_option.setEnabled(False)
     
     # Disable options that produce unbeatable seeds when not running from source.
     if not IS_RUNNING_FROM_SOURCE:

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -345,7 +345,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="1" column="2">
+               <item row="1" column="3">
                 <layout class="QHBoxLayout" name="horizontalLayout_2">
                  <item>
                   <widget class="QLabel" name="label_for_num_starting_triforce_shards">
@@ -427,6 +427,51 @@
                  </property>
                 </widget>
                </item>
+               <item row="1" column="2">
+                <layout class="QHBoxLayout" name="horizontalLayout_13">
+                 <item>
+                  <widget class="QLabel" name="label_for_num_race_mode_dungeons">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Required Dungeons</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="num_race_mode_dungeons">
+                   <property name="maximumSize">
+                    <size>
+                     <width>40</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>4</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>5</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>6</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="widget_6" native="true"/>
+                 </item>
+                </layout>
+               </item>
                <item row="0" column="1" colspan="2">
                 <layout class="QHBoxLayout" name="horizontalLayout_8">
                  <item>
@@ -490,9 +535,6 @@
                   <string>Randomize Enemy Locations</string>
                  </property>
                 </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QWidget" name="widget_5" native="true"/>
                </item>
               </layout>
              </widget>

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -438,7 +438,7 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>Required Dungeons</string>
+                    <string>Race Mode Required Dungeons</string>
                    </property>
                   </widget>
                  </item>

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -3,16 +3,13 @@
 ################################################################################
 ## Form generated from reading UI file 'randomizer_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 5.14.2
+## Created by: Qt User Interface Compiler version 5.15.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide2.QtCore import (QCoreApplication, QDate, QDateTime, QMetaObject,
-    QObject, QPoint, QRect, QSize, QTime, QUrl, Qt)
-from PySide2.QtGui import (QBrush, QColor, QConicalGradient, QCursor, QFont,
-    QFontDatabase, QIcon, QKeySequence, QLinearGradient, QPalette, QPainter,
-    QPixmap, QRadialGradient)
+from PySide2.QtCore import *
+from PySide2.QtGui import *
 from PySide2.QtWidgets import *
 
 
@@ -286,12 +283,38 @@ class Ui_MainWindow(object):
         self.horizontalLayout_2.addWidget(self.widget)
 
 
-        self.gridLayout_3.addLayout(self.horizontalLayout_2, 1, 2, 1, 1)
+        self.gridLayout_3.addLayout(self.horizontalLayout_2, 1, 3, 1, 1)
 
         self.race_mode = QCheckBox(self.groupBox_3)
         self.race_mode.setObjectName(u"race_mode")
 
         self.gridLayout_3.addWidget(self.race_mode, 1, 1, 1, 1)
+
+        self.horizontalLayout_13 = QHBoxLayout()
+        self.horizontalLayout_13.setObjectName(u"horizontalLayout_13")
+        self.label_for_num_race_mode_dungeons = QLabel(self.groupBox_3)
+        self.label_for_num_race_mode_dungeons.setObjectName(u"label_for_num_race_mode_dungeons")
+        sizePolicy.setHeightForWidth(self.label_for_num_race_mode_dungeons.sizePolicy().hasHeightForWidth())
+        self.label_for_num_race_mode_dungeons.setSizePolicy(sizePolicy)
+
+        self.horizontalLayout_13.addWidget(self.label_for_num_race_mode_dungeons)
+
+        self.num_race_mode_dungeons = QComboBox(self.groupBox_3)
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.setObjectName(u"num_race_mode_dungeons")
+        self.num_race_mode_dungeons.setMaximumSize(QSize(40, 16777215))
+
+        self.horizontalLayout_13.addWidget(self.num_race_mode_dungeons)
+
+        self.widget_6 = QWidget(self.groupBox_3)
+        self.widget_6.setObjectName(u"widget_6")
+
+        self.horizontalLayout_13.addWidget(self.widget_6)
+
+
+        self.gridLayout_3.addLayout(self.horizontalLayout_13, 1, 2, 1, 1)
 
         self.horizontalLayout_8 = QHBoxLayout()
         self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
@@ -332,11 +355,6 @@ class Ui_MainWindow(object):
         self.randomize_enemies.setObjectName(u"randomize_enemies")
 
         self.gridLayout_3.addWidget(self.randomize_enemies, 0, 3, 1, 1)
-
-        self.widget_5 = QWidget(self.groupBox_3)
-        self.widget_5.setObjectName(u"widget_5")
-
-        self.gridLayout_3.addWidget(self.widget_5, 1, 3, 1, 1)
 
 
         self.verticalLayout_2.addWidget(self.groupBox_3)
@@ -773,6 +791,11 @@ class Ui_MainWindow(object):
         self.num_starting_triforce_shards.setItemText(8, QCoreApplication.translate("MainWindow", u"8", None))
 
         self.race_mode.setText(QCoreApplication.translate("MainWindow", u"Race Mode", None))
+        self.label_for_num_race_mode_dungeons.setText(QCoreApplication.translate("MainWindow", u"Required Dungeons", None))
+        self.num_race_mode_dungeons.setItemText(0, QCoreApplication.translate("MainWindow", u"4", None))
+        self.num_race_mode_dungeons.setItemText(1, QCoreApplication.translate("MainWindow", u"5", None))
+        self.num_race_mode_dungeons.setItemText(2, QCoreApplication.translate("MainWindow", u"6", None))
+
         self.label_for_randomize_entrances.setText(QCoreApplication.translate("MainWindow", u"Randomize Entrances", None))
         self.randomize_entrances.setItemText(0, QCoreApplication.translate("MainWindow", u"Disabled", None))
         self.randomize_entrances.setItemText(1, QCoreApplication.translate("MainWindow", u"Dungeons", None))

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -791,7 +791,7 @@ class Ui_MainWindow(object):
         self.num_starting_triforce_shards.setItemText(8, QCoreApplication.translate("MainWindow", u"8", None))
 
         self.race_mode.setText(QCoreApplication.translate("MainWindow", u"Race Mode", None))
-        self.label_for_num_race_mode_dungeons.setText(QCoreApplication.translate("MainWindow", u"Required Dungeons", None))
+        self.label_for_num_race_mode_dungeons.setText(QCoreApplication.translate("MainWindow", u"Race Mode Required Dungeons", None))
         self.num_race_mode_dungeons.setItemText(0, QCoreApplication.translate("MainWindow", u"4", None))
         self.num_race_mode_dungeons.setItemText(1, QCoreApplication.translate("MainWindow", u"5", None))
         self.num_race_mode_dungeons.setItemText(2, QCoreApplication.translate("MainWindow", u"6", None))


### PR DESCRIPTION
This PR adds an option to choose the number of required dungeons in Race Mode, allowing anywhere from 4 to 6 dungeons. I didn't include options lower than 4 dungeons because that causes too many errors in dungeons-only mode.

The Boomerang and Mirror Shield are now required as additional rewards when in Swordless mode and starting with 8 Triforce Shards. I chose these items because they're required to complete bosses but aren't required for any of the entrances.

This PR relates to #121, but it doesn't cover Race Mode with 1-3 dungeons as was mentioned in the issue.