### PR TITLE
Allow fewer dungeons for Race Mode

### DIFF
--- a/logic/logic.py
+++ b/logic/logic.py
@@ -229,6 +229,44 @@ class Logic:
       num_progress_locations += 41
     
     return num_progress_locations
+
+  def get_max_race_mode_banned_locations(self):
+    if not self.rando.options.get("race_mode"):
+      return 0
+    
+    all_locations = self.item_locations.keys()
+    progress_locations = self.filter_locations_for_progression(all_locations)
+    location_counts_by_dungeon = OrderedDict()
+    
+    for location_name in progress_locations:
+      zone_name, _ = self.split_location_name_by_zone(location_name)
+      
+      dungeon_name = None
+      if self.is_dungeon_location(location_name):
+        dungeon_name = zone_name
+      elif location_name == "Mailbox - Letter from Orca":
+        dungeon_name = "Forbidden Woods"
+      elif location_name == "Mailbox - Letter from Baito":
+        dungeon_name = "Earth Temple"
+      elif location_name == "Mailbox - Letter from Aryll":
+        dungeon_name = "Forsaken Fortress"
+      elif location_name == "Mailbox - Letter from Tingle":
+        dungeon_name = "Forsaken Fortress"
+      
+      if dungeon_name is None:
+        continue
+      
+      if dungeon_name in location_counts_by_dungeon:
+        location_counts_by_dungeon[dungeon_name] += 1
+      else:
+        location_counts_by_dungeon[dungeon_name] = 1
+    
+    dungeon_location_counts = list(location_counts_by_dungeon.values())
+    dungeon_location_counts.sort(reverse=True)
+    num_banned_dungeons = 6 - int(self.rando.options.get("num_race_mode_dungeons"))
+    max_banned_locations = sum(dungeon_location_counts[:num_banned_dungeons])
+    
+    return max_banned_locations
   
   def get_progress_and_non_progress_locations(self):
     all_locations = self.item_locations.keys()

--- a/randomizer.py
+++ b/randomizer.py
@@ -307,12 +307,15 @@ class Randomizer:
     self.logic = Logic(self)
     
     num_progress_locations = self.logic.get_num_progression_locations()
+    max_race_mode_banned_locations = self.logic.get_max_race_mode_banned_locations()
     num_progress_items = self.logic.get_num_progression_items()
-    if num_progress_locations < num_progress_items: 
+    if num_progress_locations - max_race_mode_banned_locations < num_progress_items: 
       error_message = "Not enough progress locations to place all progress items.\n\n"
       error_message += "Total progress items: %d\n" % num_progress_items
-      error_message += "Progress locations with current options: %d\n\n" % num_progress_locations
-      error_message += "You need to check more of the progress location options in order to give the randomizer enough space to place all the items."
+      error_message += "Progress locations with current options: %d\n" % num_progress_locations
+      if max_race_mode_banned_locations > 0:
+        error_message += "Maximum Race Mode banned locations: %d\n" % max_race_mode_banned_locations
+      error_message += "\nYou need to check more of the progress location options in order to give the randomizer enough space to place all the items."
       raise TooFewProgressionLocationsError(error_message)
     
     # We need to determine if the user's selected options result in a dungeons-only-start.

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -450,6 +450,24 @@
                      <height>16777215</height>
                     </size>
                    </property>
+                   <property name="currentIndex">
+                    <number>3</number>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>1</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>2</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>3</string>
+                    </property>
+                   </item>
                    <item>
                     <property name="text">
                      <string>4</string>

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -303,6 +303,9 @@ class Ui_MainWindow(object):
         self.num_race_mode_dungeons.addItem("")
         self.num_race_mode_dungeons.addItem("")
         self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
         self.num_race_mode_dungeons.setObjectName(u"num_race_mode_dungeons")
         self.num_race_mode_dungeons.setMaximumSize(QSize(40, 16777215))
 
@@ -734,6 +737,7 @@ class Ui_MainWindow(object):
         self.retranslateUi(MainWindow)
 
         self.tabWidget.setCurrentIndex(0)
+        self.num_race_mode_dungeons.setCurrentIndex(3)
 
 
         QMetaObject.connectSlotsByName(MainWindow)
@@ -792,9 +796,12 @@ class Ui_MainWindow(object):
 
         self.race_mode.setText(QCoreApplication.translate("MainWindow", u"Race Mode", None))
         self.label_for_num_race_mode_dungeons.setText(QCoreApplication.translate("MainWindow", u"Race Mode Required Dungeons", None))
-        self.num_race_mode_dungeons.setItemText(0, QCoreApplication.translate("MainWindow", u"4", None))
-        self.num_race_mode_dungeons.setItemText(1, QCoreApplication.translate("MainWindow", u"5", None))
-        self.num_race_mode_dungeons.setItemText(2, QCoreApplication.translate("MainWindow", u"6", None))
+        self.num_race_mode_dungeons.setItemText(0, QCoreApplication.translate("MainWindow", u"1", None))
+        self.num_race_mode_dungeons.setItemText(1, QCoreApplication.translate("MainWindow", u"2", None))
+        self.num_race_mode_dungeons.setItemText(2, QCoreApplication.translate("MainWindow", u"3", None))
+        self.num_race_mode_dungeons.setItemText(3, QCoreApplication.translate("MainWindow", u"4", None))
+        self.num_race_mode_dungeons.setItemText(4, QCoreApplication.translate("MainWindow", u"5", None))
+        self.num_race_mode_dungeons.setItemText(5, QCoreApplication.translate("MainWindow", u"6", None))
 
         self.label_for_randomize_entrances.setText(QCoreApplication.translate("MainWindow", u"Randomize Entrances", None))
         self.randomize_entrances.setItemText(0, QCoreApplication.translate("MainWindow", u"Disabled", None))


### PR DESCRIPTION
This PR adds the option to choose between 1 to 3 dungeons in Race Mode, which allows including more overworld locations while still maintaining a short seed length.

Unfortunately, Race Mode with fewer than 4 dungeons doesn't leave enough locations for dungeon-only mode. In order to handle this case, the randomizer now subtracts the maximum possible number of banned locations from the total progress locations when determining whether to throw a `TooFewProgressionLocationsError`.

Resolves #121 