### PR TITLE
Increase speed of Link's sidle animation

### DIFF
--- a/tweaks.py
+++ b/tweaks.py
@@ -1448,8 +1448,11 @@ def increase_misc_animations(self):
   # Increase speed Link starts climbing a ladder/vine (1.0 -> 1.6)
   self.dol.write_data(write_float, 0x8035DB18, 1.6)
   
-  # Increase speed Links ends climbing a ladder/vine (0.9 -> 1.4)
+  # Increase speed Link ends climbing a ladder/vine (0.9 -> 1.4)
   self.dol.write_data(write_float, 0x8035DB20, 1.4)
+  
+  # Increase Link's sidle animation speed (1.6 -> 2.0)
+  self.dol.write_data(write_float, 0x8035D6AC, 2.0)
   
   # Half the number of frames camera takes to focus on an npc for a conversation (from 20 to 10)
   self.dol.write_data(write_u32, 0x8016DA2C, 0x3800000A) # li r0,10


### PR DESCRIPTION
To make long sidling sections more convenient, this PR slightly increases Link's sidle animation speed.

I'm not entirely sure what the value in address `8035D6AC` means, but it does make sidling faster. I'm also not sure if there are other addresses that affect the sidle speed.