### PR TITLE
Fix error when randomizing with race mode

### DIFF
--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -230,7 +230,8 @@ def validate_boss_reward_locations(self, boss_reward_locations):
     # Temporarily own dungeon boss rewards that are now accessible.
     for location_name in newly_accessible_boss_locations:
       item_name = boss_reward_locations[location_name]
-      self.logic.add_owned_item_or_item_group(item_name)
+      if item_name in self.logic.unplaced_progress_items:
+        self.logic.add_owned_item_or_item_group(item_name)
       temporary_boss_reward_items.append(item_name)
       remaining_boss_reward_items.remove(item_name)
       remaining_boss_locations.remove(location_name)
@@ -239,7 +240,8 @@ def validate_boss_reward_locations(self, boss_reward_locations):
   for item_name in items_to_temporarily_add:
     self.logic.remove_owned_item_or_item_group(item_name)
   for item_name in temporary_boss_reward_items:
-    self.logic.remove_owned_item_or_item_group(item_name)
+    if item_name in self.logic.currently_owned_items:
+      self.logic.remove_owned_item_or_item_group(item_name)
   
   return locations_valid
 


### PR DESCRIPTION
I was previously running into an error on `1841f5a` with the following permalink: `MS44LjBfMTg0MWY1YQBCbHVlRXhwZXJ0QW11c2VtZW50ABULJAAOUMAFAAAAAAAAAAA=`

![python_WV51BECNSN](https://user-images.githubusercontent.com/8262173/104797297-a45f3500-5782-11eb-9734-9e14483780b0.png)

This was because Triforce Shards were being added and removed as both a group and as individual items in `validate_boss_reward_locations`, which resulted in the randomizer later trying to place duplicate Triforce Shards. This PR adds additional checks to make sure that duplicate shards are not added or removed.

Also, `items_to_temporarily_add` in `validate_boss_reward_locations` ideally wouldn't include the Triforce Shard boss rewards, but since there aren't any entrances locked behind Triforce Shards, it doesn't matter in practice.