### PR TITLE
Update chart randomizer to support a dry run

### DIFF
--- a/randomizers/charts.py
+++ b/randomizers/charts.py
@@ -4,38 +4,47 @@ import copy
 def randomize_charts(self):
   # Shuffles around which chart points to each sector.
   
-  randomizable_charts = [chart for chart in self.chart_list.charts if chart.type in [0, 1, 2, 6]]
+  original_item_names = list(self.island_number_to_chart_name.values())
   
-  original_charts = copy.deepcopy(randomizable_charts)
-  # Sort the charts by their texture ID so we get the same results even if we randomize them multiple times.
-  original_charts.sort(key=lambda chart: chart.texture_id)
-  self.rng.shuffle(original_charts)
+  # Shuffles the list of island numbers.
+  # The shuffled island numbers determine which sector each chart points to.
+  shuffled_island_numbers = list(self.island_number_to_chart_name.keys())
+  self.rng.shuffle(shuffled_island_numbers)
   
-  for chart in randomizable_charts:
-    chart_to_copy_from = original_charts.pop()
+  if not self.dry_run:
+    randomizable_charts = [chart for chart in self.chart_list.charts if chart.type in [0, 1, 2, 6]]
+    original_charts = copy.deepcopy(randomizable_charts)
+  
+  for original_item_name in original_item_names:
+    shuffled_island_number = shuffled_island_numbers.pop()
     
-    chart.texture_id = chart_to_copy_from.texture_id
-    chart.sector_x = chart_to_copy_from.sector_x
-    chart.sector_y = chart_to_copy_from.sector_y
-    
-    for random_pos_index in range(4):
-      possible_pos = chart.possible_random_positions[random_pos_index]
-      possible_pos_to_copy_from = chart_to_copy_from.possible_random_positions[random_pos_index]
+    if not self.dry_run:
+      # Finds the corresponding charts for the shuffled island number and original item name.
+      chart_to_copy_from = next(chart for chart in original_charts if chart.island_number == shuffled_island_number)
+      chart = next(chart for chart in randomizable_charts if chart.item_name == original_item_name)
       
-      possible_pos.chart_texture_x_offset = possible_pos_to_copy_from.chart_texture_x_offset
-      possible_pos.chart_texture_y_offset = possible_pos_to_copy_from.chart_texture_y_offset
-      possible_pos.salvage_x_pos = possible_pos_to_copy_from.salvage_x_pos
-      possible_pos.salvage_y_pos = possible_pos_to_copy_from.salvage_y_pos
+      chart.texture_id = chart_to_copy_from.texture_id
+      chart.sector_x = chart_to_copy_from.sector_x
+      chart.sector_y = chart_to_copy_from.sector_y
+      
+      for random_pos_index in range(4):
+        possible_pos = chart.possible_random_positions[random_pos_index]
+        possible_pos_to_copy_from = chart_to_copy_from.possible_random_positions[random_pos_index]
+        
+        possible_pos.chart_texture_x_offset = possible_pos_to_copy_from.chart_texture_x_offset
+        possible_pos.chart_texture_y_offset = possible_pos_to_copy_from.chart_texture_y_offset
+        possible_pos.salvage_x_pos = possible_pos_to_copy_from.salvage_x_pos
+        possible_pos.salvage_y_pos = possible_pos_to_copy_from.salvage_y_pos
+      
+      chart.save_changes()
+      
+      # Then update the salvage object on the sea so it knows what chart corresponds to it now.
+      dzx = self.get_arc("files/res/Stage/sea/Room%d.arc" % chart.island_number).get_file("room.dzr")
+      for scob in dzx.entries_by_type("SCOB"):
+        if scob.actor_class_name == "d_a_salvage" and scob.salvage_type == 0:
+          scob.chart_index_plus_1 = chart.owned_chart_index_plus_1
+          scob.save_changes()
     
-    chart.save_changes()
-    
-    # Then update the salvage object on the sea so it knows what chart corresponds to it now.
-    dzx = self.get_arc("files/res/Stage/sea/Room%d.arc" % chart.island_number).get_file("room.dzr")
-    for scob in dzx.entries_by_type("SCOB"):
-      if scob.actor_class_name == "d_a_salvage" and scob.salvage_type == 0:
-        scob.chart_index_plus_1 = chart.owned_chart_index_plus_1
-        scob.save_changes()
-    
-    self.island_number_to_chart_name[chart_to_copy_from.island_number] = chart.item_name
+    self.island_number_to_chart_name[shuffled_island_number] = original_item_name
   
   self.logic.update_chart_macros()


### PR DESCRIPTION
The "Randomize Charts" option previously didn't work with a dry run. This PR updates the chart randomizer's logic such that the randomization of the island number to chart name mappings no longer relies on the chart data. The new logic produces identical results to the old logic, with the added benefit of being compatible with a dry run.