### PR TITLE
Fix permalink decode failing for starting items

### DIFF
--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -570,6 +570,7 @@ class WWRandomizerWindow(QMainWindow):
         # Reset model with only the regular items
         self.randomized_gear_model.setStringList(REGULAR_ITEMS.copy())
         self.starting_gear_model.setStringList([])
+        self.filtered_rgear.setFilterStrings([])
         for i in range(len(REGULAR_ITEMS)):
           starting = bitsreader.read(1)
           if starting == 1:


### PR DESCRIPTION
When items are filtered out, the permalink isn't decoded properly. Specifically, this causes an issue when Swordless mode is on and trying to start with any item that's later than the Hurricane Spin alphabetically.