### PR TITLE
Add Seed Hash To Log Headers

### DIFF
--- a/randomizer.py
+++ b/randomizer.py
@@ -78,6 +78,7 @@ class Randomizer:
     self.options = options
     self.seed = seed
     self.permalink = permalink
+    self.seed_hash = None
     
     self.dry_run = ("-dry" in cmd_line_args)
     self.disassemble = ("-disassemble" in cmd_line_args)
@@ -931,6 +932,9 @@ class Randomizer:
     if self.permalink:
       header += "Permalink: %s\n" % self.permalink
     
+    if self.seed_hash:
+      header += "Seed Hash: %s\n" % self.seed_hash
+
     header += "Seed: %s\n" % self.seed
     
     header += "Options selected:\n  "

--- a/tweaks.py
+++ b/tweaks.py
@@ -1661,11 +1661,12 @@ def show_seed_hash_on_name_entry_screen(self):
   name_1, name_2 = temp_rng.sample(valid_names, 2)
   name_1 = upper_first_letter(name_1)
   name_2 = upper_first_letter(name_2)
+  self.seed_hash = name_1 + " " + name_2
   
   # Since actually adding new text to the UI would be very difficult, instead hijack the "Name Entry" text, and put the seed hash after several linebreaks.
   # (The three linebreaks we insert before "Name Entry" are so it's still in the correct spot after vertical centering happens.)
   msg = self.bmg.messages_by_id[40]
-  msg.string = "\n\n\n" + msg.string + "\n\n" + "Seed hash:" + "\n" + name_1 + " " + name_2
+  msg.string = "\n\n\n" + msg.string + "\n\n" + "Seed hash:" + "\n" + self.seed_hash
 
 def fix_ghost_ship_chest_crash(self):
   # There's a vanilla crash that happens if you jump attack on top of the chest in the Ghost Ship.


### PR DESCRIPTION
This PR adds writing the seed hash to log headers. This includes spoiler logs, non-spoiler logs, and error logs. The seed hash provides runners participating in a race an alternative method to permalinks for ensuring that they have the same seed. Having the seed hash in the logs allows the runners to perform this check without having to load up the game.

Another use for this is posting the seed hash in Racetime race lobbies. A bot can (already) be used to generate permalinks for races. With this PR, the bot would also be able to pull the seed hash from the non-spoiler log and update the race info with it. This would allow runners to check whether they have the correct seed without having to ask other runners in chat.