### PR TITLE
Allow for starting with dungeon maps or compasses

### DIFF
--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -295,7 +295,6 @@ def randomize_dungeon_items(self):
     if item_name.endswith(" Dungeon Map")
     or item_name.endswith(" Compass")
   ]
-  assert len(other_dungeon_items_to_place) > 0
   for item_name in other_dungeon_items_to_place:
     place_dungeon_item(self, item_name)
   

--- a/wwr_ui/inventory.py
+++ b/wwr_ui/inventory.py
@@ -30,6 +30,16 @@ REGULAR_ITEMS = [
   "Empty Bottle",
   "Magic Meter Upgrade",
 ]
+
+DUNGEON_NONPROGRESS_ITEMS = \
+  ["DRC Dungeon Map", "DRC Compass"] + \
+  ["FW Dungeon Map", "FW Compass"] + \
+  ["TotG Dungeon Map", "TotG Compass"] + \
+  ["FF Dungeon Map", "FF Compass"] + \
+  ["ET Dungeon Map", "ET Compass"] + \
+  ["WT Dungeon Map", "WT Compass"]
+
+REGULAR_ITEMS = REGULAR_ITEMS + DUNGEON_NONPROGRESS_ITEMS
 REGULAR_ITEMS.sort()
 
 PROGRESSIVE_ITEMS = \


### PR DESCRIPTION
This PR adds the dungeon maps and compasses from the six dungeons to the starting items list. Thus, the player can start with any combination of the aforementioned dungeon items. The motivation behind this change is:

1. For consistency: The player can already select to start with most (though not all) of the obtainable items in the game. This includes non-progress items such as the Hero's Charm. This PR increases this list with the dungeon maps and compasses.
2. For racing: In a race without key-lunacy, starting with dungeon maps and compasses means two more checks in each dungeon, increasing the value of going to dungeons. Additionally, a runner cannot gamble skipping a check in the hopes that it is a dungeon item; they must check all checks in that dungeon. This changes how dungeons are routed and the overall meta surrounding dungeons, particularly when paired with settings that allow for fast dungeon clears.
3. For learning players: Starting with compasses can be helpful for newer players that are still learning where checks are in a dungeon. Seeing all the chests in the dungeon from the start helps learning players to make sure that they are not missing a check and can help with their overall dungeon routing. This is useful for racing as well, as dungeons are generally an early pain point newer runners in the racing community come across.

We have now done several races in the racing community where we start with dungeon maps and compasses, and the community generally enjoys, or at least welcomes, the change. So far, no bugs have been observed related to these changes.