### PR TITLE
Fix permissions for Mac builds

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: wwrando-${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.sha_short }}-macos-${{ steps.archvars.outputs.bitness }}bit
-          path: dist/release_archive_${{ steps.vars.outputs.version }}_${{ steps.archvars.outputs.bitness }}bit/*
+          path: dist/release_archive_${{ steps.vars.outputs.version }}_${{ steps.archvars.outputs.bitness }}bit.zip
 
   linux:
     runs-on: ubuntu-latest

--- a/build.py
+++ b/build.py
@@ -38,6 +38,7 @@ shutil.copyfile("README.md", os.path.join(release_archive_path, "README.txt"))
 if platform.system() == "Darwin":
   shutil.move(exe_path, os.path.join(release_archive_path, base_name + exe_ext))
   shutil.copyfile(os.path.join(".", "models", "About Custom Models.txt"), os.path.join(release_archive_path, "About Custom Models.txt"))
+  shutil.make_archive(release_archive_path, 'zip', release_archive_path)
 else:
   os.mkdir(os.path.join(release_archive_path, "models"))
   shutil.move(exe_path, os.path.join(release_archive_path, base_name + exe_ext))


### PR DESCRIPTION
Due to [an issue with `upload-artifact`](https://github.com/actions/upload-artifact/issues/38), the executable's permissions were not preserved. Zipping the archive prior to uploading the artifact resolves this issue.