### PR TITLE
Fix settings reset not working with Link in casual clothes

### DIFF
--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -84,7 +84,7 @@ class WWRandomizerWindow(QMainWindow):
 
     self.ui.install_custom_model.clicked.connect(self.install_custom_model_zip)
     self.ui.custom_player_model.currentIndexChanged.connect(self.custom_model_changed)
-    self.ui.player_in_casual_clothes.clicked.connect(self.in_casual_clothes_changed)
+    self.ui.player_in_casual_clothes.toggled.connect(self.in_casual_clothes_changed)
     self.ui.randomize_all_custom_colors_together.clicked.connect(self.randomize_all_custom_colors_together)
     self.ui.randomize_all_custom_colors_separately.clicked.connect(self.randomize_all_custom_colors_separately)
     self.ui.custom_color_preset.currentIndexChanged.connect(self.color_preset_changed)


### PR DESCRIPTION
As reported by @tanjo3:
> When Link is wearing casual clothes, resetting the settings to default does not reset the model correctly. This can be easily seen if you randomize colors, in addition to casual clothes, and then click "Reset All Settings to Default".

This PR updates the event for `in_casual_clothes_changed` to `toggled` instead of `clicked`, which causes it to trigger even when the checkbox state is updated programmatically with `setChecked`.