### PR TITLE
Fix hints for Wizzrobe Cave

### DIFF
--- a/logic/logic.py
+++ b/logic/logic.py
@@ -167,6 +167,15 @@ class Logic:
     
     self.cached_enemies_tested_for_reqs_tuple = OrderedDict()
   
+  def is_dungeon_or_cave(self, location_name):
+    # Look up the setting that the location name is under
+    is_dungeon = "Dungeon" in self.item_locations[location_name]["Types"]
+    is_puzzle_cave = "Puzzle Secret Cave" in self.item_locations[location_name]["Types"]
+    is_combat_cave = "Combat Secret Cave" in self.item_locations[location_name]["Types"]
+    is_savage = "Savage Labyrinth" in self.item_locations[location_name]["Types"]
+    
+    return (is_dungeon or is_puzzle_cave or is_combat_cave or is_savage)
+  
   def set_location_to_item(self, location_name, item_name):
     #print("Setting %s to %s" % (location_name, item_name))
     

--- a/randomizers/entrances.py
+++ b/randomizers/entrances.py
@@ -208,7 +208,10 @@ def randomize_one_set_of_entrances(self, include_dungeons=False, include_caves=F
     remaining_exits.remove(zone_exit)
     
     self.entrance_connections[zone_entrance.entrance_name] = zone_exit.unique_name
-    self.dungeon_and_cave_island_locations[zone_exit.zone_name] = zone_entrance.island_name
+    if zone_exit.unique_name == "Pawprint Isle Wizzrobe Cave":
+      self.dungeon_and_cave_island_locations["Pawprint Isle Side Isle"] = zone_entrance.island_name
+    else:
+      self.dungeon_and_cave_island_locations[zone_exit.zone_name] = zone_entrance.island_name
     done_entrances_to_exits[zone_entrance] = zone_exit
     
     if not self.dry_run:

--- a/tweaks.py
+++ b/tweaks.py
@@ -926,11 +926,12 @@ def randomize_and_update_hints(self):
       break
     
     zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
-    is_dungeon = "Dungeon" in self.logic.item_locations[location_name]["Types"]
-    is_puzzle_cave = "Puzzle Secret Cave" in self.logic.item_locations[location_name]["Types"]
-    is_combat_cave = "Combat Secret Cave" in self.logic.item_locations[location_name]["Types"]
-    is_savage = "Savage Labyrinth" in self.logic.item_locations[location_name]["Types"]
-    if zone_name in self.dungeon_and_cave_island_locations and (is_dungeon or is_puzzle_cave or is_combat_cave or is_savage):
+    
+    # Distinguish between the two Pawprint Isle entrances when secret cave entrances are randomized
+    if self.options.get("randomize_entrances") not in ["Disabled", "Dungeons", None] and location_name == "Pawprint Isle - Wizzrobe Cave":
+      zone_name = "Pawprint Isle Side Isle"
+    
+    if zone_name in self.dungeon_and_cave_island_locations and self.logic.is_dungeon_or_cave(location_name):
       # If the location is in a dungeon or cave, use the hint for whatever island the dungeon/cave is located on.
       island_name = self.dungeon_and_cave_island_locations[zone_name]
       island_hint_name = self.island_name_hints[island_name]


### PR DESCRIPTION
This PR fixes hints for Pawprint Isle - Wizzrobe Cave. Previously, when secret cave entrances were randomized, the hint for an item in the Wizzrobe Cave would use the entrance to Pawprint Isle Chuchu Cave instead. This PR address this by adding Pawprint Isle Side Isle to `dungeon_and_cave_island_locations` in `Logic.py` separately from the Chuchu Cave. A check is then made to use the correct entrance when a hint for the Wizzrobe Cave is made.