### PR TITLE
Add King of Red Lions as a hint placement option

### DIFF
--- a/hints.py
+++ b/hints.py
@@ -31,10 +31,11 @@ def generate_item_hints(self, num_hints):
   octo_fairy_hint = None
   fishmen_hints = []
   hoho_hints = []
+  korl_hints = []
   unique_hints = []
   
   # Identify where the user wishes hints to be located
-  variable_hint_placement_options = ["fishmen_hints", "hoho_hints"]
+  variable_hint_placement_options = ["fishmen_hints", "hoho_hints", "korl_hints"]
   num_hint_placements = sum(self.options.get(option) for option in variable_hint_placement_options)
   
   # Always assign one hint to the Big Octo Great Fairy
@@ -121,6 +122,8 @@ def generate_item_hints(self, num_hints):
       fishmen_hints.append(item_hint)
     elif current_hint_placement == "hoho_hints":
       hoho_hints.append(item_hint)
+    elif current_hint_placement == "korl_hints":
+      korl_hints.append(item_hint)
     
     # Move the next hint placement
     hints_remaining_per_placement[current_hint_placement] -= 1
@@ -143,11 +146,18 @@ def generate_item_hints(self, num_hints):
     # Duplicate a hint that we've already made.
     hoho_hints.append(self.rng.choice([octo_fairy_hint] + fishmen_hints))
   
+  if self.options.get("korl_hints") and len(korl_hints) == 0:
+    # Unable to make a hint for King of Red Lions, but was able to make one for the Big Octo Great Fairy and the fishmen.
+    # Duplicate a hint that we've already made.
+    korl_hints.append(self.rng.choice([octo_fairy_hint] + fishmen_hints))
+  
   # Loop through the hints, converting the item and location names to hint strings
   octo_fairy_hint = (self.progress_item_hints[octo_fairy_hint[0]], self.island_name_hints[octo_fairy_hint[1]])
   for i, hint in enumerate(fishmen_hints):
     fishmen_hints[i] = (self.progress_item_hints[hint[0]], self.island_name_hints[hint[1]])
   for i, hint in enumerate(hoho_hints):
     hoho_hints[i] = (self.progress_item_hints[hint[0]], self.island_name_hints[hint[1]])
+  for i, hint in enumerate(korl_hints):
+    korl_hints[i] = (self.progress_item_hints[hint[0]], self.island_name_hints[hint[1]])
   
-  return octo_fairy_hint, fishmen_hints, hoho_hints
+  return octo_fairy_hint, fishmen_hints, hoho_hints, korl_hints

--- a/randomizer.py
+++ b/randomizer.py
@@ -70,6 +70,7 @@ CLEAN_WIND_WAKER_ISO_MD5 = 0xd8e4d45af2032a081a0f446384e9261b
 RNG_CHANGING_OPTIONS = [
   "fishmen_hints",
   "hoho_hints",
+  "korl_hints",
   "num_hints",
   "do_not_generate_spoiler_log",
 ]

--- a/tweaks.py
+++ b/tweaks.py
@@ -887,7 +887,7 @@ def randomize_and_update_hints(self):
   num_hints = int(self.options.get("num_hints", 0))
   
   # Generate item hints
-  octo_fairy_hint, fishmen_hints, hoho_hints = hints.generate_item_hints(self, 1+num_hints)
+  octo_fairy_hint, fishmen_hints, hoho_hints, korl_hints = hints.generate_item_hints(self, 1+num_hints)
   
   # Give the Big Octo Great Fairy a unique item hint
   update_big_octo_great_fairy_item_name_hint(self, octo_fairy_hint)
@@ -897,6 +897,8 @@ def randomize_and_update_hints(self):
     update_fishmen_hints(self, fishmen_hints)
   if self.options.get("hoho_hints"):
     update_hoho_hints(self, hoho_hints)
+  if self.options.get("korl_hints"):
+    update_korl_hints(self, korl_hints)
 
 def update_fishmen_hints(self, item_hints):
   islands = list(range(1, 49+1))
@@ -960,6 +962,22 @@ def update_hoho_hints(self, item_hints):
       hint += hint_line
     
     msg_id = 14001 + hoho_index
+    msg = self.bmg.messages_by_id[msg_id]
+    msg.string = hint
+
+def update_korl_hints(self, item_hints):
+  hint_lines = []
+  for i, hint in enumerate(item_hints):
+    # Have no delay with KoRL text since he potentially has a lot of textboxes
+    hint_lines.append(hints.get_formatted_hint_text(hint, prefix="They say that ", suffix=".", delay=0))
+  
+  hint = ""
+  for hint_line in hint_lines:
+    hint_line = word_wrap_string(hint_line)
+    hint_line = pad_string_to_next_4_lines(hint_line)
+    hint += hint_line
+  
+  for msg_id in (3443, 3444, 3445, 3446, 3447, 3448):
     msg = self.bmg.messages_by_id[msg_id]
     msg.string = hint
 

--- a/tweaks.py
+++ b/tweaks.py
@@ -969,7 +969,9 @@ def update_korl_hints(self, item_hints):
   hint_lines = []
   for i, hint in enumerate(item_hints):
     # Have no delay with KoRL text since he potentially has a lot of textboxes
-    hint_lines.append(hints.get_formatted_hint_text(hint, prefix="They say that ", suffix=".", delay=0))
+    hint_prefix = "They say that " if i == 0 else "and that "
+    hint_suffix = "." if i == len(item_hints) - 1 else ","
+    hint_lines.append(hints.get_formatted_hint_text(hint, prefix=hint_prefix, suffix=hint_suffix, delay=0))
   
   hint = ""
   for hint_line in hint_lines:

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -121,6 +121,10 @@ OPTIONS = OrderedDict([
     "Places hints on Old Man Ho Ho. Old Man Ho Ho appears at 10 different islands in the game. Simply talk to Old Man Ho Ho to get hints.",
   ),
   (
+    "korl_hints",
+    "Places hints on King of Red Lions. Talk to King of Red Lions to get all of the hints.",
+  ),
+  (
     "num_hints",
     "Determines the number of hints that will be placed in the game. This option does not affect Wallet mail, Big Octo Great Fairy, or Savage Labyrinth hints.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
   ),

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -122,7 +122,7 @@ OPTIONS = OrderedDict([
   ),
   (
     "korl_hints",
-    "Places hints on King of Red Lions. Talk to King of Red Lions to get all of the hints.",
+    "Places hints on the King of Red Lions. Talk to the King of Red Lions to get hints.",
   ),
   (
     "num_hints",

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -28,12 +28,12 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>925</width>
-         <height>710</height>
+         <width>908</width>
+         <height>716</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_4">
-        <property name="margin">
+        <property name="margin" stdset="0">
          <number>0</number>
         </property>
         <item>
@@ -614,7 +614,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="2">
+               <item row="0" column="3">
                 <layout class="QHBoxLayout" name="horizontalLayout_7">
                  <item>
                   <widget class="QLabel" name="label_for_num_hints">
@@ -641,8 +641,12 @@
                  </item>
                 </layout>
                </item>
-               <item row="0" column="3">
-                <widget class="QWidget" name="widget_4" native="true"/>
+               <item row="0" column="2">
+                <widget class="QCheckBox" name="korl_hints">
+                 <property name="text">
+                  <string>Place Hints on King of Red Lions</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -895,7 +899,7 @@
                 <property name="value">
                  <number>0</number>
                 </property>
-                <property name="displayIntegerBase" stdset="0">
+                <property name="displayIntegerBase">
                  <number>10</number>
                 </property>
                </widget>
@@ -915,7 +919,7 @@
                 <property name="value">
                  <number>0</number>
                 </property>
-                <property name="displayIntegerBase" stdset="0">
+                <property name="displayIntegerBase">
                  <number>10</number>
                 </property>
                </widget>

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>943</width>
-    <height>844</height>
+    <width>950</width>
+    <height>690</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,11 +28,11 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>908</width>
-         <height>716</height>
+         <width>915</width>
+         <height>558</height>
         </rect>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="margin" stdset="0">
          <number>0</number>
         </property>
@@ -48,7 +48,7 @@
            <attribute name="title">
             <string>Randomizer Settings</string>
            </attribute>
-           <layout class="QVBoxLayout" name="verticalLayout_2">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
             <item>
              <layout class="QGridLayout" name="gridLayout">
               <item row="2" column="1">
@@ -294,8 +294,107 @@
                <string>Additional Randomization Options</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_3">
-               <item row="1" column="3">
-                <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <item row="0" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_3">
+                 <item>
+                  <widget class="QLabel" name="label_for_sword_mode">
+                   <property name="text">
+                    <string>Sword Mode</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="sword_mode">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>1</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>Start with Hero's Sword</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>No Starting Sword</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Swordless</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item row="0" column="2" colspan="2">
+                <layout class="QHBoxLayout" name="horizontalLayout_5">
+                 <item>
+                  <widget class="QLabel" name="label_for_randomize_entrances">
+                   <property name="text">
+                    <string>Randomize Entrances</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="randomize_entrances">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>1</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>Disabled</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Dungeons</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Secret Caves</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Dungeons &amp; Secret Caves (Separately)</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Dungeons &amp; Secret Caves (Together)</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="widget_2" native="true"/>
+                 </item>
+                </layout>
+               </item>
+               <item row="1" column="0">
+                <widget class="QCheckBox" name="keylunacy">
+                 <property name="text">
+                  <string>Key-Lunacy</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="chest_type_matches_contents">
+                 <property name="text">
+                  <string>Chest Type Matches Contents</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_4">
                  <item>
                   <widget class="QLabel" name="label_for_num_starting_triforce_shards">
                    <property name="sizePolicy">
@@ -371,219 +470,44 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QWidget" name="widget_2" native="true"/>
+                  <widget class="QWidget" name="widget" native="true"/>
                  </item>
                 </layout>
                </item>
-               <item row="2" column="1">
-                <widget class="QCheckBox" name="randomize_starting_island">
-                 <property name="text">
-                  <string>Randomize Starting Island</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="2">
-                <widget class="QCheckBox" name="randomize_enemy_palettes">
-                 <property name="text">
-                  <string>Randomize Enemy Palettes</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="3">
-                <widget class="QCheckBox" name="randomize_music">
-                 <property name="text">
-                  <string>Randomize Music</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_3">
-                 <item>
-                  <widget class="QLabel" name="label_for_sword_mode">
-                   <property name="text">
-                    <string>Sword Mode</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="sword_mode">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>1</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <item>
-                    <property name="text">
-                     <string>Start with Hero's Sword</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>No Starting Sword</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Swordless</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item row="0" column="3">
-                <widget class="QCheckBox" name="randomize_enemies">
-                 <property name="text">
-                  <string>Randomize Enemy Locations</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QCheckBox" name="chest_type_matches_contents">
-                 <property name="text">
-                  <string>Chest Type Matches Contents</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
+               <item row="1" column="1">
                 <widget class="QCheckBox" name="randomize_charts">
                  <property name="text">
                   <string>Randomize Charts</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="1">
-                <widget class="QCheckBox" name="race_mode">
+               <item row="2" column="1">
+                <widget class="QCheckBox" name="randomize_music">
                  <property name="text">
-                  <string>Race Mode</string>
+                  <string>Randomize Music</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <widget class="QCheckBox" name="randomize_enemies">
+                 <property name="text">
+                  <string>Randomize Enemy Locations</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="2">
-                <layout class="QHBoxLayout" name="horizontalLayout_5">
-                 <item>
-                  <widget class="QLabel" name="label_for_num_race_mode_dungeons">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>Race Mode Required Dungeons</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="num_race_mode_dungeons">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>1</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>40</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="currentIndex">
-                    <number>3</number>
-                   </property>
-                   <item>
-                    <property name="text">
-                     <string>1</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>2</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>3</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>4</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>5</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>6</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QWidget" name="widget_1" native="true"/>
-                 </item>
-                </layout>
-               </item>
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="keylunacy">
+                <widget class="QCheckBox" name="randomize_starting_island">
                  <property name="text">
-                  <string>Key-Lunacy</string>
+                  <string>Randomize Starting Island</string>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="1" colspan="2">
-                <layout class="QHBoxLayout" name="horizontalLayout_4">
-                 <item>
-                  <widget class="QLabel" name="label_for_randomize_entrances">
-                   <property name="text">
-                    <string>Randomize Entrances</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="randomize_entrances">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>1</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <item>
-                    <property name="text">
-                     <string>Disabled</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Dungeons</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Secret Caves</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Dungeons &amp; Secret Caves (Separately)</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Dungeons &amp; Secret Caves (Together)</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QWidget" name="widget" native="true"/>
-                 </item>
-                </layout>
+               <item row="1" column="3">
+                <widget class="QCheckBox" name="randomize_enemy_palettes">
+                 <property name="text">
+                  <string>Randomize Enemy Palettes</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -591,76 +515,37 @@
             <item>
              <widget class="QGroupBox" name="groupBox_3">
               <property name="title">
-               <string>Hint Options</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_7">
-               <item row="0" column="0">
-                <widget class="QCheckBox" name="fishmen_hints">
-                 <property name="text">
-                  <string>Place Hints on Fishmen</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QCheckBox" name="hoho_hints">
-                 <property name="text">
-                  <string>Place Hints on Old Man Ho Ho</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <layout class="QHBoxLayout" name="horizontalLayout_7">
-                 <item>
-                  <widget class="QLabel" name="label_for_num_hints">
-                   <property name="text">
-                    <string>Hint Count</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="num_hints">
-                   <property name="minimum">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <number>32</number>
-                   </property>
-                   <property name="value">
-                    <number>20</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QWidget" name="widget_3" native="true"/>
-                 </item>
-                </layout>
-               </item>
-               <item row="0" column="2">
-                <widget class="QCheckBox" name="korl_hints">
-                 <property name="text">
-                  <string>Place Hints on King of Red Lions</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox_4">
-              <property name="title">
                <string>Convenience Tweaks</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_4">
-               <item row="1" column="2">
-                <widget class="QCheckBox" name="remove_title_and_ending_videos">
+               <item row="0" column="3">
+                <widget class="QCheckBox" name="invert_camera_x_axis">
                  <property name="text">
-                  <string>Remove Title and Ending Videos</string>
+                  <string>Invert Camera X-Axis</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QCheckBox" name="swift_sail">
+                 <property name="text">
+                  <string>Swift Sail</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="3">
+                <widget class="QCheckBox" name="remove_music">
+                 <property name="text">
+                  <string>Remove Music</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QCheckBox" name="reveal_full_sea_chart">
+                 <property name="text">
+                  <string>Reveal Full Sea Chart</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>
@@ -677,51 +562,13 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="0">
-                <widget class="QCheckBox" name="swift_sail">
+               <item row="1" column="2">
+                <widget class="QCheckBox" name="remove_title_and_ending_videos">
                  <property name="text">
-                  <string>Swift Sail</string>
+                  <string>Remove Title and Ending Videos</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QCheckBox" name="invert_sea_compass_x_axis">
-                 <property name="text">
-                  <string>Invert Sea Compass X-Axis</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QCheckBox" name="remove_music">
-                 <property name="text">
-                  <string>Remove Music</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <widget class="QCheckBox" name="invert_camera_x_axis">
-                 <property name="text">
-                  <string>Invert Camera X-Axis</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QCheckBox" name="reveal_full_sea_chart">
-                 <property name="text">
-                  <string>Reveal Full Sea Chart</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QCheckBox" name="add_shortcut_warps_between_dungeons">
-                 <property name="text">
-                  <string>Add Shortcut Warps Between Dungeons</string>
                  </property>
                 </widget>
                </item>
@@ -735,34 +582,19 @@
                  </property>
                 </widget>
                </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox_5">
-              <property name="title">
-               <string>Advanced Options</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_6">
-               <item row="0" column="3">
-                <widget class="QWidget" name="widget_6" native="true"/>
-               </item>
-               <item row="0" column="1">
-                <widget class="QCheckBox" name="disable_tingle_chests_with_tingle_bombs">
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="add_shortcut_warps_between_dungeons">
                  <property name="text">
-                  <string>Tingle Bombs Don't Open Tingle Chests</string>
+                  <string>Add Shortcut Warps Between Dungeons</string>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="0">
-                <widget class="QCheckBox" name="do_not_generate_spoiler_log">
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="invert_sea_compass_x_axis">
                  <property name="text">
-                  <string>Do Not Generate Spoiler Log</string>
+                  <string>Invert Sea Compass X-Axis</string>
                  </property>
                 </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QWidget" name="widget_5" native="true"/>
                </item>
               </layout>
              </widget>
@@ -776,11 +608,11 @@
            <attribute name="title">
             <string>Starting Items</string>
            </attribute>
-           <layout class="QVBoxLayout" name="verticalLayout_10">
+           <layout class="QVBoxLayout" name="verticalLayout_4">
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <layout class="QHBoxLayout" name="horizontalLayout_6">
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_8">
+               <layout class="QVBoxLayout" name="verticalLayout_5">
                 <item>
                  <widget class="QLabel" name="label_for_randomized_gear">
                   <property name="text">
@@ -801,7 +633,7 @@
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_7">
+               <layout class="QVBoxLayout" name="verticalLayout_6">
                 <item>
                  <spacer name="verticalSpacer">
                   <property name="orientation">
@@ -857,7 +689,7 @@
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_9">
+               <layout class="QVBoxLayout" name="verticalLayout_7">
                 <item>
                  <widget class="QLabel" name="label_for_starting_gear">
                   <property name="text">
@@ -880,7 +712,7 @@
              </layout>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_9">
+             <layout class="QHBoxLayout" name="horizontalLayout_7">
               <item>
                <widget class="QLabel" name="label_for_starting_hcs">
                 <property name="text">
@@ -948,15 +780,218 @@
             </item>
            </layout>
           </widget>
+          <widget class="QWidget" name="tab">
+           <attribute name="title">
+            <string>Advanced Options</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_8">
+            <item>
+             <widget class="QGroupBox" name="groupBox_4">
+              <property name="title">
+               <string>Race Mode Options</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_6">
+               <item row="0" column="2">
+                <widget class="QWidget" name="widget_4" native="true"/>
+               </item>
+               <item row="0" column="0">
+                <widget class="QCheckBox" name="race_mode">
+                 <property name="text">
+                  <string>Race Mode</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_8">
+                 <item>
+                  <widget class="QLabel" name="label_for_num_race_mode_dungeons">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Race Mode Required Dungeons</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="num_race_mode_dungeons">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>1</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>40</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="currentIndex">
+                    <number>3</number>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>1</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>2</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>3</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>4</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>5</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>6</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="widget_3" native="true"/>
+                 </item>
+                </layout>
+               </item>
+               <item row="0" column="3">
+                <widget class="QWidget" name="widget_5" native="true"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox_5">
+              <property name="title">
+               <string>Hint Options</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_9">
+               <item row="0" column="0">
+                <widget class="QCheckBox" name="fishmen_hints">
+                 <property name="text">
+                  <string>Place Hints on Fishmen</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QCheckBox" name="hoho_hints">
+                 <property name="text">
+                  <string>Place Hints on Old Man Ho Ho</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <layout class="QHBoxLayout" name="horizontalLayout_9">
+                 <item>
+                  <widget class="QLabel" name="label_for_num_hints">
+                   <property name="text">
+                    <string>Hint Count</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QSpinBox" name="num_hints">
+                   <property name="minimum">
+                    <number>1</number>
+                   </property>
+                   <property name="maximum">
+                    <number>32</number>
+                   </property>
+                   <property name="value">
+                    <number>20</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="widget_6" native="true"/>
+                 </item>
+                </layout>
+               </item>
+               <item row="0" column="2">
+                <widget class="QCheckBox" name="korl_hints">
+                 <property name="text">
+                  <string>Place Hints on King of Red Lions</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox_6">
+              <property name="title">
+               <string>Additional Advanced Options</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_8">
+               <item row="0" column="3">
+                <widget class="QWidget" name="widget_7" native="true"/>
+               </item>
+               <item row="0" column="1">
+                <widget class="QCheckBox" name="disable_tingle_chests_with_tingle_bombs">
+                 <property name="text">
+                  <string>Tingle Bombs Don't Open Tingle Chests</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QCheckBox" name="do_not_generate_spoiler_log">
+                 <property name="text">
+                  <string>Do Not Generate Spoiler Log</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QWidget" name="widget_8" native="true"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
           <widget class="QWidget" name="tab_player_customization">
            <attribute name="title">
             <string>Player Customization</string>
            </attribute>
-           <layout class="QVBoxLayout" name="verticalLayout_3">
+           <layout class="QVBoxLayout" name="verticalLayout_9">
             <item>
              <layout class="QGridLayout" name="gridLayout_5">
               <item row="2" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout_12">
+               <layout class="QHBoxLayout" name="horizontalLayout_10">
                 <item>
                  <widget class="QLabel" name="label_for_custom_color_preset">
                   <property name="text">
@@ -970,7 +1005,7 @@
                </layout>
               </item>
               <item row="2" column="1">
-               <layout class="QHBoxLayout" name="horizontalLayout_13">
+               <layout class="QHBoxLayout" name="horizontalLayout_11">
                 <item>
                  <widget class="QPushButton" name="randomize_all_custom_colors_together">
                   <property name="text">
@@ -988,7 +1023,7 @@
                </layout>
               </item>
               <item row="1" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout_10">
+               <layout class="QHBoxLayout" name="horizontalLayout_12">
                 <item>
                  <widget class="QLabel" name="label_for_custom_player_model">
                   <property name="text">
@@ -1002,7 +1037,7 @@
                </layout>
               </item>
               <item row="1" column="1">
-               <layout class="QHBoxLayout" name="horizontalLayout_11">
+               <layout class="QHBoxLayout" name="horizontalLayout_13">
                 <item>
                  <widget class="QCheckBox" name="player_in_casual_clothes">
                   <property name="text">
@@ -1054,12 +1089,12 @@
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_14">
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_5">
+               <layout class="QVBoxLayout" name="verticalLayout_10">
                 <item>
                  <layout class="QVBoxLayout" name="custom_colors_layout"/>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer_3">
+                 <spacer name="verticalSpacer_4">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -1074,7 +1109,7 @@
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_6">
+               <layout class="QVBoxLayout" name="verticalLayout_11">
                 <item>
                  <widget class="QLabel" name="custom_model_preview_label">
                   <property name="text">
@@ -1083,7 +1118,7 @@
                  </widget>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer_4">
+                 <spacer name="verticalSpacer_5">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -36,7 +36,7 @@ class Ui_MainWindow(object):
         self.scrollArea.setWidgetResizable(True)
         self.scrollAreaWidgetContents = QWidget()
         self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
-        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 925, 710))
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 908, 716))
         self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout_4.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_4.setObjectName(u"verticalLayout_4")
@@ -423,12 +423,12 @@ class Ui_MainWindow(object):
         self.horizontalLayout_7.addWidget(self.widget_3)
 
 
-        self.gridLayout_7.addLayout(self.horizontalLayout_7, 0, 2, 1, 1)
+        self.gridLayout_7.addLayout(self.horizontalLayout_7, 0, 3, 1, 1)
 
-        self.widget_4 = QWidget(self.groupBox_3)
-        self.widget_4.setObjectName(u"widget_4")
+        self.korl_hints = QCheckBox(self.groupBox_3)
+        self.korl_hints.setObjectName(u"korl_hints")
 
-        self.gridLayout_7.addWidget(self.widget_4, 0, 3, 1, 1)
+        self.gridLayout_7.addWidget(self.korl_hints, 0, 2, 1, 1)
 
 
         self.verticalLayout_2.addWidget(self.groupBox_3)
@@ -599,7 +599,7 @@ class Ui_MainWindow(object):
         self.starting_hcs.setLayoutDirection(Qt.LeftToRight)
         self.starting_hcs.setMaximum(6)
         self.starting_hcs.setValue(0)
-        self.starting_hcs.setProperty("displayIntegerBase", 10)
+        self.starting_hcs.setDisplayIntegerBase(10)
 
         self.horizontalLayout_9.addWidget(self.starting_hcs)
 
@@ -612,7 +612,7 @@ class Ui_MainWindow(object):
         self.starting_pohs.setObjectName(u"starting_pohs")
         self.starting_pohs.setMaximum(44)
         self.starting_pohs.setValue(0)
-        self.starting_pohs.setProperty("displayIntegerBase", 10)
+        self.starting_pohs.setDisplayIntegerBase(10)
 
         self.horizontalLayout_9.addWidget(self.starting_pohs)
 
@@ -899,6 +899,7 @@ class Ui_MainWindow(object):
         self.fishmen_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Fishmen", None))
         self.hoho_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Old Man Ho Ho", None))
         self.label_for_num_hints.setText(QCoreApplication.translate("MainWindow", u"Hint Count", None))
+        self.korl_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on King of Red Lions", None))
         self.groupBox_4.setTitle(QCoreApplication.translate("MainWindow", u"Convenience Tweaks", None))
         self.remove_title_and_ending_videos.setText(QCoreApplication.translate("MainWindow", u"Remove Title and Ending Videos", None))
         self.instant_text_boxes.setText(QCoreApplication.translate("MainWindow", u"Instant Text Boxes", None))

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -25,7 +25,7 @@ class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         if not MainWindow.objectName():
             MainWindow.setObjectName(u"MainWindow")
-        MainWindow.resize(943, 844)
+        MainWindow.resize(950, 690)
         self.centralwidget = QWidget(MainWindow)
         self.centralwidget.setObjectName(u"centralwidget")
         self.verticalLayout = QVBoxLayout(self.centralwidget)
@@ -36,17 +36,17 @@ class Ui_MainWindow(object):
         self.scrollArea.setWidgetResizable(True)
         self.scrollAreaWidgetContents = QWidget()
         self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
-        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 908, 716))
-        self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents)
-        self.verticalLayout_4.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 915, 558))
+        self.verticalLayout_2 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.tabWidget = QTabWidget(self.scrollAreaWidgetContents)
         self.tabWidget.setObjectName(u"tabWidget")
         self.tabWidget.setEnabled(True)
         self.tab_randomizer_settings = QWidget()
         self.tab_randomizer_settings.setObjectName(u"tab_randomizer_settings")
-        self.verticalLayout_2 = QVBoxLayout(self.tab_randomizer_settings)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_3 = QVBoxLayout(self.tab_randomizer_settings)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
         self.seed = QLineEdit(self.tab_randomizer_settings)
@@ -95,7 +95,7 @@ class Ui_MainWindow(object):
         self.gridLayout.addWidget(self.clean_iso_path_browse_button, 0, 2, 1, 1)
 
 
-        self.verticalLayout_2.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.gridLayout)
 
         self.groupBox = QGroupBox(self.tab_randomizer_settings)
         self.groupBox.setObjectName(u"groupBox")
@@ -219,67 +219,12 @@ class Ui_MainWindow(object):
         self.gridLayout_2.addWidget(self.progression_island_puzzles, 6, 3, 1, 1)
 
 
-        self.verticalLayout_2.addWidget(self.groupBox)
+        self.verticalLayout_3.addWidget(self.groupBox)
 
         self.groupBox_2 = QGroupBox(self.tab_randomizer_settings)
         self.groupBox_2.setObjectName(u"groupBox_2")
         self.gridLayout_3 = QGridLayout(self.groupBox_2)
         self.gridLayout_3.setObjectName(u"gridLayout_3")
-        self.horizontalLayout_6 = QHBoxLayout()
-        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
-        self.label_for_num_starting_triforce_shards = QLabel(self.groupBox_2)
-        self.label_for_num_starting_triforce_shards.setObjectName(u"label_for_num_starting_triforce_shards")
-        sizePolicy = QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Preferred)
-        sizePolicy.setHorizontalStretch(0)
-        sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.label_for_num_starting_triforce_shards.sizePolicy().hasHeightForWidth())
-        self.label_for_num_starting_triforce_shards.setSizePolicy(sizePolicy)
-
-        self.horizontalLayout_6.addWidget(self.label_for_num_starting_triforce_shards)
-
-        self.num_starting_triforce_shards = QComboBox(self.groupBox_2)
-        self.num_starting_triforce_shards.addItem("")
-        self.num_starting_triforce_shards.addItem("")
-        self.num_starting_triforce_shards.addItem("")
-        self.num_starting_triforce_shards.addItem("")
-        self.num_starting_triforce_shards.addItem("")
-        self.num_starting_triforce_shards.addItem("")
-        self.num_starting_triforce_shards.addItem("")
-        self.num_starting_triforce_shards.addItem("")
-        self.num_starting_triforce_shards.addItem("")
-        self.num_starting_triforce_shards.setObjectName(u"num_starting_triforce_shards")
-        sizePolicy1 = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
-        sizePolicy1.setHorizontalStretch(1)
-        sizePolicy1.setVerticalStretch(0)
-        sizePolicy1.setHeightForWidth(self.num_starting_triforce_shards.sizePolicy().hasHeightForWidth())
-        self.num_starting_triforce_shards.setSizePolicy(sizePolicy1)
-        self.num_starting_triforce_shards.setMaximumSize(QSize(40, 16777215))
-
-        self.horizontalLayout_6.addWidget(self.num_starting_triforce_shards)
-
-        self.widget_2 = QWidget(self.groupBox_2)
-        self.widget_2.setObjectName(u"widget_2")
-
-        self.horizontalLayout_6.addWidget(self.widget_2)
-
-
-        self.gridLayout_3.addLayout(self.horizontalLayout_6, 1, 3, 1, 1)
-
-        self.randomize_starting_island = QCheckBox(self.groupBox_2)
-        self.randomize_starting_island.setObjectName(u"randomize_starting_island")
-
-        self.gridLayout_3.addWidget(self.randomize_starting_island, 2, 1, 1, 1)
-
-        self.randomize_enemy_palettes = QCheckBox(self.groupBox_2)
-        self.randomize_enemy_palettes.setObjectName(u"randomize_enemy_palettes")
-
-        self.gridLayout_3.addWidget(self.randomize_enemy_palettes, 2, 2, 1, 1)
-
-        self.randomize_music = QCheckBox(self.groupBox_2)
-        self.randomize_music.setObjectName(u"randomize_music")
-
-        self.gridLayout_3.addWidget(self.randomize_music, 2, 3, 1, 1)
-
         self.horizontalLayout_3 = QHBoxLayout()
         self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
         self.label_for_sword_mode = QLabel(self.groupBox_2)
@@ -292,76 +237,23 @@ class Ui_MainWindow(object):
         self.sword_mode.addItem("")
         self.sword_mode.addItem("")
         self.sword_mode.setObjectName(u"sword_mode")
-        sizePolicy1.setHeightForWidth(self.sword_mode.sizePolicy().hasHeightForWidth())
-        self.sword_mode.setSizePolicy(sizePolicy1)
+        sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
+        sizePolicy.setHorizontalStretch(1)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.sword_mode.sizePolicy().hasHeightForWidth())
+        self.sword_mode.setSizePolicy(sizePolicy)
 
         self.horizontalLayout_3.addWidget(self.sword_mode)
 
 
         self.gridLayout_3.addLayout(self.horizontalLayout_3, 0, 0, 1, 1)
 
-        self.randomize_enemies = QCheckBox(self.groupBox_2)
-        self.randomize_enemies.setObjectName(u"randomize_enemies")
-
-        self.gridLayout_3.addWidget(self.randomize_enemies, 0, 3, 1, 1)
-
-        self.chest_type_matches_contents = QCheckBox(self.groupBox_2)
-        self.chest_type_matches_contents.setObjectName(u"chest_type_matches_contents")
-
-        self.gridLayout_3.addWidget(self.chest_type_matches_contents, 3, 0, 1, 1)
-
-        self.randomize_charts = QCheckBox(self.groupBox_2)
-        self.randomize_charts.setObjectName(u"randomize_charts")
-
-        self.gridLayout_3.addWidget(self.randomize_charts, 2, 0, 1, 1)
-
-        self.race_mode = QCheckBox(self.groupBox_2)
-        self.race_mode.setObjectName(u"race_mode")
-
-        self.gridLayout_3.addWidget(self.race_mode, 1, 1, 1, 1)
-
         self.horizontalLayout_5 = QHBoxLayout()
         self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
-        self.label_for_num_race_mode_dungeons = QLabel(self.groupBox_2)
-        self.label_for_num_race_mode_dungeons.setObjectName(u"label_for_num_race_mode_dungeons")
-        sizePolicy.setHeightForWidth(self.label_for_num_race_mode_dungeons.sizePolicy().hasHeightForWidth())
-        self.label_for_num_race_mode_dungeons.setSizePolicy(sizePolicy)
-
-        self.horizontalLayout_5.addWidget(self.label_for_num_race_mode_dungeons)
-
-        self.num_race_mode_dungeons = QComboBox(self.groupBox_2)
-        self.num_race_mode_dungeons.addItem("")
-        self.num_race_mode_dungeons.addItem("")
-        self.num_race_mode_dungeons.addItem("")
-        self.num_race_mode_dungeons.addItem("")
-        self.num_race_mode_dungeons.addItem("")
-        self.num_race_mode_dungeons.addItem("")
-        self.num_race_mode_dungeons.setObjectName(u"num_race_mode_dungeons")
-        sizePolicy1.setHeightForWidth(self.num_race_mode_dungeons.sizePolicy().hasHeightForWidth())
-        self.num_race_mode_dungeons.setSizePolicy(sizePolicy1)
-        self.num_race_mode_dungeons.setMaximumSize(QSize(40, 16777215))
-
-        self.horizontalLayout_5.addWidget(self.num_race_mode_dungeons)
-
-        self.widget_1 = QWidget(self.groupBox_2)
-        self.widget_1.setObjectName(u"widget_1")
-
-        self.horizontalLayout_5.addWidget(self.widget_1)
-
-
-        self.gridLayout_3.addLayout(self.horizontalLayout_5, 1, 2, 1, 1)
-
-        self.keylunacy = QCheckBox(self.groupBox_2)
-        self.keylunacy.setObjectName(u"keylunacy")
-
-        self.gridLayout_3.addWidget(self.keylunacy, 1, 0, 1, 1)
-
-        self.horizontalLayout_4 = QHBoxLayout()
-        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
         self.label_for_randomize_entrances = QLabel(self.groupBox_2)
         self.label_for_randomize_entrances.setObjectName(u"label_for_randomize_entrances")
 
-        self.horizontalLayout_4.addWidget(self.label_for_randomize_entrances)
+        self.horizontalLayout_5.addWidget(self.label_for_randomize_entrances)
 
         self.randomize_entrances = QComboBox(self.groupBox_2)
         self.randomize_entrances.addItem("")
@@ -370,10 +262,57 @@ class Ui_MainWindow(object):
         self.randomize_entrances.addItem("")
         self.randomize_entrances.addItem("")
         self.randomize_entrances.setObjectName(u"randomize_entrances")
-        sizePolicy1.setHeightForWidth(self.randomize_entrances.sizePolicy().hasHeightForWidth())
-        self.randomize_entrances.setSizePolicy(sizePolicy1)
+        sizePolicy.setHeightForWidth(self.randomize_entrances.sizePolicy().hasHeightForWidth())
+        self.randomize_entrances.setSizePolicy(sizePolicy)
 
-        self.horizontalLayout_4.addWidget(self.randomize_entrances)
+        self.horizontalLayout_5.addWidget(self.randomize_entrances)
+
+        self.widget_2 = QWidget(self.groupBox_2)
+        self.widget_2.setObjectName(u"widget_2")
+
+        self.horizontalLayout_5.addWidget(self.widget_2)
+
+
+        self.gridLayout_3.addLayout(self.horizontalLayout_5, 0, 2, 1, 2)
+
+        self.keylunacy = QCheckBox(self.groupBox_2)
+        self.keylunacy.setObjectName(u"keylunacy")
+
+        self.gridLayout_3.addWidget(self.keylunacy, 1, 0, 1, 1)
+
+        self.chest_type_matches_contents = QCheckBox(self.groupBox_2)
+        self.chest_type_matches_contents.setObjectName(u"chest_type_matches_contents")
+
+        self.gridLayout_3.addWidget(self.chest_type_matches_contents, 2, 0, 1, 1)
+
+        self.horizontalLayout_4 = QHBoxLayout()
+        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+        self.label_for_num_starting_triforce_shards = QLabel(self.groupBox_2)
+        self.label_for_num_starting_triforce_shards.setObjectName(u"label_for_num_starting_triforce_shards")
+        sizePolicy1 = QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Preferred)
+        sizePolicy1.setHorizontalStretch(0)
+        sizePolicy1.setVerticalStretch(0)
+        sizePolicy1.setHeightForWidth(self.label_for_num_starting_triforce_shards.sizePolicy().hasHeightForWidth())
+        self.label_for_num_starting_triforce_shards.setSizePolicy(sizePolicy1)
+
+        self.horizontalLayout_4.addWidget(self.label_for_num_starting_triforce_shards)
+
+        self.num_starting_triforce_shards = QComboBox(self.groupBox_2)
+        self.num_starting_triforce_shards.addItem("")
+        self.num_starting_triforce_shards.addItem("")
+        self.num_starting_triforce_shards.addItem("")
+        self.num_starting_triforce_shards.addItem("")
+        self.num_starting_triforce_shards.addItem("")
+        self.num_starting_triforce_shards.addItem("")
+        self.num_starting_triforce_shards.addItem("")
+        self.num_starting_triforce_shards.addItem("")
+        self.num_starting_triforce_shards.addItem("")
+        self.num_starting_triforce_shards.setObjectName(u"num_starting_triforce_shards")
+        sizePolicy.setHeightForWidth(self.num_starting_triforce_shards.sizePolicy().hasHeightForWidth())
+        self.num_starting_triforce_shards.setSizePolicy(sizePolicy)
+        self.num_starting_triforce_shards.setMaximumSize(QSize(40, 16777215))
+
+        self.horizontalLayout_4.addWidget(self.num_starting_triforce_shards)
 
         self.widget = QWidget(self.groupBox_2)
         self.widget.setObjectName(u"widget")
@@ -381,218 +320,169 @@ class Ui_MainWindow(object):
         self.horizontalLayout_4.addWidget(self.widget)
 
 
-        self.gridLayout_3.addLayout(self.horizontalLayout_4, 0, 1, 1, 2)
+        self.gridLayout_3.addLayout(self.horizontalLayout_4, 0, 1, 1, 1)
+
+        self.randomize_charts = QCheckBox(self.groupBox_2)
+        self.randomize_charts.setObjectName(u"randomize_charts")
+
+        self.gridLayout_3.addWidget(self.randomize_charts, 1, 1, 1, 1)
+
+        self.randomize_music = QCheckBox(self.groupBox_2)
+        self.randomize_music.setObjectName(u"randomize_music")
+
+        self.gridLayout_3.addWidget(self.randomize_music, 2, 1, 1, 1)
+
+        self.randomize_enemies = QCheckBox(self.groupBox_2)
+        self.randomize_enemies.setObjectName(u"randomize_enemies")
+
+        self.gridLayout_3.addWidget(self.randomize_enemies, 2, 2, 1, 1)
+
+        self.randomize_starting_island = QCheckBox(self.groupBox_2)
+        self.randomize_starting_island.setObjectName(u"randomize_starting_island")
+
+        self.gridLayout_3.addWidget(self.randomize_starting_island, 1, 2, 1, 1)
+
+        self.randomize_enemy_palettes = QCheckBox(self.groupBox_2)
+        self.randomize_enemy_palettes.setObjectName(u"randomize_enemy_palettes")
+
+        self.gridLayout_3.addWidget(self.randomize_enemy_palettes, 1, 3, 1, 1)
 
 
-        self.verticalLayout_2.addWidget(self.groupBox_2)
+        self.verticalLayout_3.addWidget(self.groupBox_2)
 
         self.groupBox_3 = QGroupBox(self.tab_randomizer_settings)
         self.groupBox_3.setObjectName(u"groupBox_3")
-        self.gridLayout_7 = QGridLayout(self.groupBox_3)
-        self.gridLayout_7.setObjectName(u"gridLayout_7")
-        self.fishmen_hints = QCheckBox(self.groupBox_3)
-        self.fishmen_hints.setObjectName(u"fishmen_hints")
-        self.fishmen_hints.setChecked(True)
-
-        self.gridLayout_7.addWidget(self.fishmen_hints, 0, 0, 1, 1)
-
-        self.hoho_hints = QCheckBox(self.groupBox_3)
-        self.hoho_hints.setObjectName(u"hoho_hints")
-        self.hoho_hints.setChecked(True)
-
-        self.gridLayout_7.addWidget(self.hoho_hints, 0, 1, 1, 1)
-
-        self.horizontalLayout_7 = QHBoxLayout()
-        self.horizontalLayout_7.setObjectName(u"horizontalLayout_7")
-        self.label_for_num_hints = QLabel(self.groupBox_3)
-        self.label_for_num_hints.setObjectName(u"label_for_num_hints")
-
-        self.horizontalLayout_7.addWidget(self.label_for_num_hints)
-
-        self.num_hints = QSpinBox(self.groupBox_3)
-        self.num_hints.setObjectName(u"num_hints")
-        self.num_hints.setMinimum(1)
-        self.num_hints.setMaximum(32)
-        self.num_hints.setValue(20)
-
-        self.horizontalLayout_7.addWidget(self.num_hints)
-
-        self.widget_3 = QWidget(self.groupBox_3)
-        self.widget_3.setObjectName(u"widget_3")
-
-        self.horizontalLayout_7.addWidget(self.widget_3)
-
-
-        self.gridLayout_7.addLayout(self.horizontalLayout_7, 0, 3, 1, 1)
-
-        self.korl_hints = QCheckBox(self.groupBox_3)
-        self.korl_hints.setObjectName(u"korl_hints")
-
-        self.gridLayout_7.addWidget(self.korl_hints, 0, 2, 1, 1)
-
-
-        self.verticalLayout_2.addWidget(self.groupBox_3)
-
-        self.groupBox_4 = QGroupBox(self.tab_randomizer_settings)
-        self.groupBox_4.setObjectName(u"groupBox_4")
-        self.gridLayout_4 = QGridLayout(self.groupBox_4)
+        self.gridLayout_4 = QGridLayout(self.groupBox_3)
         self.gridLayout_4.setObjectName(u"gridLayout_4")
-        self.remove_title_and_ending_videos = QCheckBox(self.groupBox_4)
-        self.remove_title_and_ending_videos.setObjectName(u"remove_title_and_ending_videos")
-        self.remove_title_and_ending_videos.setChecked(True)
+        self.invert_camera_x_axis = QCheckBox(self.groupBox_3)
+        self.invert_camera_x_axis.setObjectName(u"invert_camera_x_axis")
 
-        self.gridLayout_4.addWidget(self.remove_title_and_ending_videos, 1, 2, 1, 1)
+        self.gridLayout_4.addWidget(self.invert_camera_x_axis, 0, 3, 1, 1)
 
-        self.instant_text_boxes = QCheckBox(self.groupBox_4)
-        self.instant_text_boxes.setObjectName(u"instant_text_boxes")
-        self.instant_text_boxes.setChecked(True)
-
-        self.gridLayout_4.addWidget(self.instant_text_boxes, 0, 1, 1, 1)
-
-        self.swift_sail = QCheckBox(self.groupBox_4)
+        self.swift_sail = QCheckBox(self.groupBox_3)
         self.swift_sail.setObjectName(u"swift_sail")
         self.swift_sail.setChecked(True)
 
         self.gridLayout_4.addWidget(self.swift_sail, 0, 0, 1, 1)
 
-        self.invert_sea_compass_x_axis = QCheckBox(self.groupBox_4)
-        self.invert_sea_compass_x_axis.setObjectName(u"invert_sea_compass_x_axis")
-
-        self.gridLayout_4.addWidget(self.invert_sea_compass_x_axis, 2, 0, 1, 1)
-
-        self.remove_music = QCheckBox(self.groupBox_4)
+        self.remove_music = QCheckBox(self.groupBox_3)
         self.remove_music.setObjectName(u"remove_music")
 
         self.gridLayout_4.addWidget(self.remove_music, 1, 3, 1, 1)
 
-        self.invert_camera_x_axis = QCheckBox(self.groupBox_4)
-        self.invert_camera_x_axis.setObjectName(u"invert_camera_x_axis")
-
-        self.gridLayout_4.addWidget(self.invert_camera_x_axis, 0, 3, 1, 1)
-
-        self.reveal_full_sea_chart = QCheckBox(self.groupBox_4)
+        self.reveal_full_sea_chart = QCheckBox(self.groupBox_3)
         self.reveal_full_sea_chart.setObjectName(u"reveal_full_sea_chart")
         self.reveal_full_sea_chart.setChecked(True)
 
         self.gridLayout_4.addWidget(self.reveal_full_sea_chart, 0, 2, 1, 1)
 
-        self.add_shortcut_warps_between_dungeons = QCheckBox(self.groupBox_4)
-        self.add_shortcut_warps_between_dungeons.setObjectName(u"add_shortcut_warps_between_dungeons")
+        self.instant_text_boxes = QCheckBox(self.groupBox_3)
+        self.instant_text_boxes.setObjectName(u"instant_text_boxes")
+        self.instant_text_boxes.setChecked(True)
 
-        self.gridLayout_4.addWidget(self.add_shortcut_warps_between_dungeons, 1, 1, 1, 1)
+        self.gridLayout_4.addWidget(self.instant_text_boxes, 0, 1, 1, 1)
 
-        self.skip_rematch_bosses = QCheckBox(self.groupBox_4)
+        self.remove_title_and_ending_videos = QCheckBox(self.groupBox_3)
+        self.remove_title_and_ending_videos.setObjectName(u"remove_title_and_ending_videos")
+        self.remove_title_and_ending_videos.setChecked(True)
+
+        self.gridLayout_4.addWidget(self.remove_title_and_ending_videos, 1, 2, 1, 1)
+
+        self.skip_rematch_bosses = QCheckBox(self.groupBox_3)
         self.skip_rematch_bosses.setObjectName(u"skip_rematch_bosses")
         self.skip_rematch_bosses.setChecked(True)
 
         self.gridLayout_4.addWidget(self.skip_rematch_bosses, 1, 0, 1, 1)
 
+        self.add_shortcut_warps_between_dungeons = QCheckBox(self.groupBox_3)
+        self.add_shortcut_warps_between_dungeons.setObjectName(u"add_shortcut_warps_between_dungeons")
 
-        self.verticalLayout_2.addWidget(self.groupBox_4)
+        self.gridLayout_4.addWidget(self.add_shortcut_warps_between_dungeons, 1, 1, 1, 1)
 
-        self.groupBox_5 = QGroupBox(self.tab_randomizer_settings)
-        self.groupBox_5.setObjectName(u"groupBox_5")
-        self.gridLayout_6 = QGridLayout(self.groupBox_5)
-        self.gridLayout_6.setObjectName(u"gridLayout_6")
-        self.widget_6 = QWidget(self.groupBox_5)
-        self.widget_6.setObjectName(u"widget_6")
+        self.invert_sea_compass_x_axis = QCheckBox(self.groupBox_3)
+        self.invert_sea_compass_x_axis.setObjectName(u"invert_sea_compass_x_axis")
 
-        self.gridLayout_6.addWidget(self.widget_6, 0, 3, 1, 1)
-
-        self.disable_tingle_chests_with_tingle_bombs = QCheckBox(self.groupBox_5)
-        self.disable_tingle_chests_with_tingle_bombs.setObjectName(u"disable_tingle_chests_with_tingle_bombs")
-
-        self.gridLayout_6.addWidget(self.disable_tingle_chests_with_tingle_bombs, 0, 1, 1, 1)
-
-        self.do_not_generate_spoiler_log = QCheckBox(self.groupBox_5)
-        self.do_not_generate_spoiler_log.setObjectName(u"do_not_generate_spoiler_log")
-
-        self.gridLayout_6.addWidget(self.do_not_generate_spoiler_log, 0, 0, 1, 1)
-
-        self.widget_5 = QWidget(self.groupBox_5)
-        self.widget_5.setObjectName(u"widget_5")
-
-        self.gridLayout_6.addWidget(self.widget_5, 0, 2, 1, 1)
+        self.gridLayout_4.addWidget(self.invert_sea_compass_x_axis, 2, 0, 1, 1)
 
 
-        self.verticalLayout_2.addWidget(self.groupBox_5)
+        self.verticalLayout_3.addWidget(self.groupBox_3)
 
         self.tabWidget.addTab(self.tab_randomizer_settings, "")
         self.tab_starting_items = QWidget()
         self.tab_starting_items.setObjectName(u"tab_starting_items")
         self.tab_starting_items.setEnabled(True)
-        self.verticalLayout_10 = QVBoxLayout(self.tab_starting_items)
-        self.verticalLayout_10.setObjectName(u"verticalLayout_10")
-        self.horizontalLayout_8 = QHBoxLayout()
-        self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
-        self.verticalLayout_8 = QVBoxLayout()
-        self.verticalLayout_8.setObjectName(u"verticalLayout_8")
+        self.verticalLayout_4 = QVBoxLayout(self.tab_starting_items)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
+        self.horizontalLayout_6 = QHBoxLayout()
+        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
+        self.verticalLayout_5 = QVBoxLayout()
+        self.verticalLayout_5.setObjectName(u"verticalLayout_5")
         self.label_for_randomized_gear = QLabel(self.tab_starting_items)
         self.label_for_randomized_gear.setObjectName(u"label_for_randomized_gear")
 
-        self.verticalLayout_8.addWidget(self.label_for_randomized_gear)
+        self.verticalLayout_5.addWidget(self.label_for_randomized_gear)
 
         self.randomized_gear = QListView(self.tab_starting_items)
         self.randomized_gear.setObjectName(u"randomized_gear")
         self.randomized_gear.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.randomized_gear.setSelectionMode(QAbstractItemView.ExtendedSelection)
 
-        self.verticalLayout_8.addWidget(self.randomized_gear)
+        self.verticalLayout_5.addWidget(self.randomized_gear)
 
 
-        self.horizontalLayout_8.addLayout(self.verticalLayout_8)
+        self.horizontalLayout_6.addLayout(self.verticalLayout_5)
 
-        self.verticalLayout_7 = QVBoxLayout()
-        self.verticalLayout_7.setObjectName(u"verticalLayout_7")
+        self.verticalLayout_6 = QVBoxLayout()
+        self.verticalLayout_6.setObjectName(u"verticalLayout_6")
         self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
-        self.verticalLayout_7.addItem(self.verticalSpacer)
+        self.verticalLayout_6.addItem(self.verticalSpacer)
 
         self.remove_gear = QPushButton(self.tab_starting_items)
         self.remove_gear.setObjectName(u"remove_gear")
         self.remove_gear.setMinimumSize(QSize(0, 80))
 
-        self.verticalLayout_7.addWidget(self.remove_gear)
+        self.verticalLayout_6.addWidget(self.remove_gear)
 
         self.add_gear = QPushButton(self.tab_starting_items)
         self.add_gear.setObjectName(u"add_gear")
         self.add_gear.setMinimumSize(QSize(0, 80))
 
-        self.verticalLayout_7.addWidget(self.add_gear)
+        self.verticalLayout_6.addWidget(self.add_gear)
 
         self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
-        self.verticalLayout_7.addItem(self.verticalSpacer_2)
+        self.verticalLayout_6.addItem(self.verticalSpacer_2)
 
 
-        self.horizontalLayout_8.addLayout(self.verticalLayout_7)
+        self.horizontalLayout_6.addLayout(self.verticalLayout_6)
 
-        self.verticalLayout_9 = QVBoxLayout()
-        self.verticalLayout_9.setObjectName(u"verticalLayout_9")
+        self.verticalLayout_7 = QVBoxLayout()
+        self.verticalLayout_7.setObjectName(u"verticalLayout_7")
         self.label_for_starting_gear = QLabel(self.tab_starting_items)
         self.label_for_starting_gear.setObjectName(u"label_for_starting_gear")
 
-        self.verticalLayout_9.addWidget(self.label_for_starting_gear)
+        self.verticalLayout_7.addWidget(self.label_for_starting_gear)
 
         self.starting_gear = QListView(self.tab_starting_items)
         self.starting_gear.setObjectName(u"starting_gear")
         self.starting_gear.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.starting_gear.setSelectionMode(QAbstractItemView.ExtendedSelection)
 
-        self.verticalLayout_9.addWidget(self.starting_gear)
+        self.verticalLayout_7.addWidget(self.starting_gear)
 
 
-        self.horizontalLayout_8.addLayout(self.verticalLayout_9)
+        self.horizontalLayout_6.addLayout(self.verticalLayout_7)
 
 
-        self.verticalLayout_10.addLayout(self.horizontalLayout_8)
+        self.verticalLayout_4.addLayout(self.horizontalLayout_6)
 
-        self.horizontalLayout_9 = QHBoxLayout()
-        self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
+        self.horizontalLayout_7 = QHBoxLayout()
+        self.horizontalLayout_7.setObjectName(u"horizontalLayout_7")
         self.label_for_starting_hcs = QLabel(self.tab_starting_items)
         self.label_for_starting_hcs.setObjectName(u"label_for_starting_hcs")
 
-        self.horizontalLayout_9.addWidget(self.label_for_starting_hcs)
+        self.horizontalLayout_7.addWidget(self.label_for_starting_hcs)
 
         self.starting_hcs = QSpinBox(self.tab_starting_items)
         self.starting_hcs.setObjectName(u"starting_hcs")
@@ -601,12 +491,12 @@ class Ui_MainWindow(object):
         self.starting_hcs.setValue(0)
         self.starting_hcs.setDisplayIntegerBase(10)
 
-        self.horizontalLayout_9.addWidget(self.starting_hcs)
+        self.horizontalLayout_7.addWidget(self.starting_hcs)
 
         self.label_for_starting_pohs = QLabel(self.tab_starting_items)
         self.label_for_starting_pohs.setObjectName(u"label_for_starting_pohs")
 
-        self.horizontalLayout_9.addWidget(self.label_for_starting_pohs)
+        self.horizontalLayout_7.addWidget(self.label_for_starting_pohs)
 
         self.starting_pohs = QSpinBox(self.tab_starting_items)
         self.starting_pohs.setObjectName(u"starting_pohs")
@@ -614,91 +504,227 @@ class Ui_MainWindow(object):
         self.starting_pohs.setValue(0)
         self.starting_pohs.setDisplayIntegerBase(10)
 
-        self.horizontalLayout_9.addWidget(self.starting_pohs)
+        self.horizontalLayout_7.addWidget(self.starting_pohs)
 
         self.current_health = QLabel(self.tab_starting_items)
         self.current_health.setObjectName(u"current_health")
 
-        self.horizontalLayout_9.addWidget(self.current_health)
+        self.horizontalLayout_7.addWidget(self.current_health)
 
         self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout_9.addItem(self.horizontalSpacer_3)
+        self.horizontalLayout_7.addItem(self.horizontalSpacer_3)
 
 
-        self.verticalLayout_10.addLayout(self.horizontalLayout_9)
+        self.verticalLayout_4.addLayout(self.horizontalLayout_7)
 
         self.tabWidget.addTab(self.tab_starting_items, "")
+        self.tab = QWidget()
+        self.tab.setObjectName(u"tab")
+        self.verticalLayout_8 = QVBoxLayout(self.tab)
+        self.verticalLayout_8.setObjectName(u"verticalLayout_8")
+        self.groupBox_4 = QGroupBox(self.tab)
+        self.groupBox_4.setObjectName(u"groupBox_4")
+        self.gridLayout_6 = QGridLayout(self.groupBox_4)
+        self.gridLayout_6.setObjectName(u"gridLayout_6")
+        self.widget_4 = QWidget(self.groupBox_4)
+        self.widget_4.setObjectName(u"widget_4")
+
+        self.gridLayout_6.addWidget(self.widget_4, 0, 2, 1, 1)
+
+        self.race_mode = QCheckBox(self.groupBox_4)
+        self.race_mode.setObjectName(u"race_mode")
+
+        self.gridLayout_6.addWidget(self.race_mode, 0, 0, 1, 1)
+
+        self.horizontalLayout_8 = QHBoxLayout()
+        self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
+        self.label_for_num_race_mode_dungeons = QLabel(self.groupBox_4)
+        self.label_for_num_race_mode_dungeons.setObjectName(u"label_for_num_race_mode_dungeons")
+        sizePolicy1.setHeightForWidth(self.label_for_num_race_mode_dungeons.sizePolicy().hasHeightForWidth())
+        self.label_for_num_race_mode_dungeons.setSizePolicy(sizePolicy1)
+
+        self.horizontalLayout_8.addWidget(self.label_for_num_race_mode_dungeons)
+
+        self.num_race_mode_dungeons = QComboBox(self.groupBox_4)
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.addItem("")
+        self.num_race_mode_dungeons.setObjectName(u"num_race_mode_dungeons")
+        sizePolicy.setHeightForWidth(self.num_race_mode_dungeons.sizePolicy().hasHeightForWidth())
+        self.num_race_mode_dungeons.setSizePolicy(sizePolicy)
+        self.num_race_mode_dungeons.setMaximumSize(QSize(40, 16777215))
+
+        self.horizontalLayout_8.addWidget(self.num_race_mode_dungeons)
+
+        self.widget_3 = QWidget(self.groupBox_4)
+        self.widget_3.setObjectName(u"widget_3")
+
+        self.horizontalLayout_8.addWidget(self.widget_3)
+
+
+        self.gridLayout_6.addLayout(self.horizontalLayout_8, 0, 1, 1, 1)
+
+        self.widget_5 = QWidget(self.groupBox_4)
+        self.widget_5.setObjectName(u"widget_5")
+
+        self.gridLayout_6.addWidget(self.widget_5, 0, 3, 1, 1)
+
+
+        self.verticalLayout_8.addWidget(self.groupBox_4)
+
+        self.groupBox_5 = QGroupBox(self.tab)
+        self.groupBox_5.setObjectName(u"groupBox_5")
+        self.gridLayout_9 = QGridLayout(self.groupBox_5)
+        self.gridLayout_9.setObjectName(u"gridLayout_9")
+        self.fishmen_hints = QCheckBox(self.groupBox_5)
+        self.fishmen_hints.setObjectName(u"fishmen_hints")
+        self.fishmen_hints.setChecked(True)
+
+        self.gridLayout_9.addWidget(self.fishmen_hints, 0, 0, 1, 1)
+
+        self.hoho_hints = QCheckBox(self.groupBox_5)
+        self.hoho_hints.setObjectName(u"hoho_hints")
+        self.hoho_hints.setChecked(True)
+
+        self.gridLayout_9.addWidget(self.hoho_hints, 0, 1, 1, 1)
+
+        self.horizontalLayout_9 = QHBoxLayout()
+        self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
+        self.label_for_num_hints = QLabel(self.groupBox_5)
+        self.label_for_num_hints.setObjectName(u"label_for_num_hints")
+
+        self.horizontalLayout_9.addWidget(self.label_for_num_hints)
+
+        self.num_hints = QSpinBox(self.groupBox_5)
+        self.num_hints.setObjectName(u"num_hints")
+        self.num_hints.setMinimum(1)
+        self.num_hints.setMaximum(32)
+        self.num_hints.setValue(20)
+
+        self.horizontalLayout_9.addWidget(self.num_hints)
+
+        self.widget_6 = QWidget(self.groupBox_5)
+        self.widget_6.setObjectName(u"widget_6")
+
+        self.horizontalLayout_9.addWidget(self.widget_6)
+
+
+        self.gridLayout_9.addLayout(self.horizontalLayout_9, 0, 3, 1, 1)
+
+        self.korl_hints = QCheckBox(self.groupBox_5)
+        self.korl_hints.setObjectName(u"korl_hints")
+
+        self.gridLayout_9.addWidget(self.korl_hints, 0, 2, 1, 1)
+
+
+        self.verticalLayout_8.addWidget(self.groupBox_5)
+
+        self.groupBox_6 = QGroupBox(self.tab)
+        self.groupBox_6.setObjectName(u"groupBox_6")
+        self.gridLayout_8 = QGridLayout(self.groupBox_6)
+        self.gridLayout_8.setObjectName(u"gridLayout_8")
+        self.widget_7 = QWidget(self.groupBox_6)
+        self.widget_7.setObjectName(u"widget_7")
+
+        self.gridLayout_8.addWidget(self.widget_7, 0, 3, 1, 1)
+
+        self.disable_tingle_chests_with_tingle_bombs = QCheckBox(self.groupBox_6)
+        self.disable_tingle_chests_with_tingle_bombs.setObjectName(u"disable_tingle_chests_with_tingle_bombs")
+
+        self.gridLayout_8.addWidget(self.disable_tingle_chests_with_tingle_bombs, 0, 1, 1, 1)
+
+        self.do_not_generate_spoiler_log = QCheckBox(self.groupBox_6)
+        self.do_not_generate_spoiler_log.setObjectName(u"do_not_generate_spoiler_log")
+
+        self.gridLayout_8.addWidget(self.do_not_generate_spoiler_log, 0, 0, 1, 1)
+
+        self.widget_8 = QWidget(self.groupBox_6)
+        self.widget_8.setObjectName(u"widget_8")
+
+        self.gridLayout_8.addWidget(self.widget_8, 0, 2, 1, 1)
+
+
+        self.verticalLayout_8.addWidget(self.groupBox_6)
+
+        self.verticalSpacer_3 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+
+        self.verticalLayout_8.addItem(self.verticalSpacer_3)
+
+        self.tabWidget.addTab(self.tab, "")
         self.tab_player_customization = QWidget()
         self.tab_player_customization.setObjectName(u"tab_player_customization")
-        self.verticalLayout_3 = QVBoxLayout(self.tab_player_customization)
-        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.verticalLayout_9 = QVBoxLayout(self.tab_player_customization)
+        self.verticalLayout_9.setObjectName(u"verticalLayout_9")
         self.gridLayout_5 = QGridLayout()
         self.gridLayout_5.setObjectName(u"gridLayout_5")
-        self.horizontalLayout_12 = QHBoxLayout()
-        self.horizontalLayout_12.setObjectName(u"horizontalLayout_12")
+        self.horizontalLayout_10 = QHBoxLayout()
+        self.horizontalLayout_10.setObjectName(u"horizontalLayout_10")
         self.label_for_custom_color_preset = QLabel(self.tab_player_customization)
         self.label_for_custom_color_preset.setObjectName(u"label_for_custom_color_preset")
 
-        self.horizontalLayout_12.addWidget(self.label_for_custom_color_preset)
+        self.horizontalLayout_10.addWidget(self.label_for_custom_color_preset)
 
         self.custom_color_preset = QComboBox(self.tab_player_customization)
         self.custom_color_preset.setObjectName(u"custom_color_preset")
 
-        self.horizontalLayout_12.addWidget(self.custom_color_preset)
+        self.horizontalLayout_10.addWidget(self.custom_color_preset)
 
 
-        self.gridLayout_5.addLayout(self.horizontalLayout_12, 2, 0, 1, 1)
+        self.gridLayout_5.addLayout(self.horizontalLayout_10, 2, 0, 1, 1)
 
-        self.horizontalLayout_13 = QHBoxLayout()
-        self.horizontalLayout_13.setObjectName(u"horizontalLayout_13")
+        self.horizontalLayout_11 = QHBoxLayout()
+        self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
         self.randomize_all_custom_colors_together = QPushButton(self.tab_player_customization)
         self.randomize_all_custom_colors_together.setObjectName(u"randomize_all_custom_colors_together")
 
-        self.horizontalLayout_13.addWidget(self.randomize_all_custom_colors_together)
+        self.horizontalLayout_11.addWidget(self.randomize_all_custom_colors_together)
 
         self.randomize_all_custom_colors_separately = QPushButton(self.tab_player_customization)
         self.randomize_all_custom_colors_separately.setObjectName(u"randomize_all_custom_colors_separately")
 
-        self.horizontalLayout_13.addWidget(self.randomize_all_custom_colors_separately)
+        self.horizontalLayout_11.addWidget(self.randomize_all_custom_colors_separately)
 
 
-        self.gridLayout_5.addLayout(self.horizontalLayout_13, 2, 1, 1, 1)
+        self.gridLayout_5.addLayout(self.horizontalLayout_11, 2, 1, 1, 1)
 
-        self.horizontalLayout_10 = QHBoxLayout()
-        self.horizontalLayout_10.setObjectName(u"horizontalLayout_10")
+        self.horizontalLayout_12 = QHBoxLayout()
+        self.horizontalLayout_12.setObjectName(u"horizontalLayout_12")
         self.label_for_custom_player_model = QLabel(self.tab_player_customization)
         self.label_for_custom_player_model.setObjectName(u"label_for_custom_player_model")
 
-        self.horizontalLayout_10.addWidget(self.label_for_custom_player_model)
+        self.horizontalLayout_12.addWidget(self.label_for_custom_player_model)
 
         self.custom_player_model = QComboBox(self.tab_player_customization)
         self.custom_player_model.setObjectName(u"custom_player_model")
 
-        self.horizontalLayout_10.addWidget(self.custom_player_model)
+        self.horizontalLayout_12.addWidget(self.custom_player_model)
 
 
-        self.gridLayout_5.addLayout(self.horizontalLayout_10, 1, 0, 1, 1)
+        self.gridLayout_5.addLayout(self.horizontalLayout_12, 1, 0, 1, 1)
 
-        self.horizontalLayout_11 = QHBoxLayout()
-        self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
+        self.horizontalLayout_13 = QHBoxLayout()
+        self.horizontalLayout_13.setObjectName(u"horizontalLayout_13")
         self.player_in_casual_clothes = QCheckBox(self.tab_player_customization)
         self.player_in_casual_clothes.setObjectName(u"player_in_casual_clothes")
 
-        self.horizontalLayout_11.addWidget(self.player_in_casual_clothes)
+        self.horizontalLayout_13.addWidget(self.player_in_casual_clothes)
 
         self.disable_custom_player_voice = QCheckBox(self.tab_player_customization)
         self.disable_custom_player_voice.setObjectName(u"disable_custom_player_voice")
 
-        self.horizontalLayout_11.addWidget(self.disable_custom_player_voice)
+        self.horizontalLayout_13.addWidget(self.disable_custom_player_voice)
 
         self.disable_custom_player_items = QCheckBox(self.tab_player_customization)
         self.disable_custom_player_items.setObjectName(u"disable_custom_player_items")
 
-        self.horizontalLayout_11.addWidget(self.disable_custom_player_items)
+        self.horizontalLayout_13.addWidget(self.disable_custom_player_items)
 
 
-        self.gridLayout_5.addLayout(self.horizontalLayout_11, 1, 1, 1, 1)
+        self.gridLayout_5.addLayout(self.horizontalLayout_13, 1, 1, 1, 1)
 
         self.install_custom_model = QPushButton(self.tab_player_customization)
         self.install_custom_model.setObjectName(u"install_custom_model")
@@ -706,51 +732,51 @@ class Ui_MainWindow(object):
         self.gridLayout_5.addWidget(self.install_custom_model, 0, 0, 1, 2)
 
 
-        self.verticalLayout_3.addLayout(self.gridLayout_5)
+        self.verticalLayout_9.addLayout(self.gridLayout_5)
 
         self.custom_model_comment = QLabel(self.tab_player_customization)
         self.custom_model_comment.setObjectName(u"custom_model_comment")
         self.custom_model_comment.setMaximumSize(QSize(810, 16777215))
         self.custom_model_comment.setWordWrap(True)
 
-        self.verticalLayout_3.addWidget(self.custom_model_comment)
+        self.verticalLayout_9.addWidget(self.custom_model_comment)
 
         self.horizontalLayout_14 = QHBoxLayout()
         self.horizontalLayout_14.setObjectName(u"horizontalLayout_14")
-        self.verticalLayout_5 = QVBoxLayout()
-        self.verticalLayout_5.setObjectName(u"verticalLayout_5")
+        self.verticalLayout_10 = QVBoxLayout()
+        self.verticalLayout_10.setObjectName(u"verticalLayout_10")
         self.custom_colors_layout = QVBoxLayout()
         self.custom_colors_layout.setObjectName(u"custom_colors_layout")
 
-        self.verticalLayout_5.addLayout(self.custom_colors_layout)
-
-        self.verticalSpacer_3 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
-
-        self.verticalLayout_5.addItem(self.verticalSpacer_3)
-
-
-        self.horizontalLayout_14.addLayout(self.verticalLayout_5)
-
-        self.verticalLayout_6 = QVBoxLayout()
-        self.verticalLayout_6.setObjectName(u"verticalLayout_6")
-        self.custom_model_preview_label = QLabel(self.tab_player_customization)
-        self.custom_model_preview_label.setObjectName(u"custom_model_preview_label")
-
-        self.verticalLayout_6.addWidget(self.custom_model_preview_label)
+        self.verticalLayout_10.addLayout(self.custom_colors_layout)
 
         self.verticalSpacer_4 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
-        self.verticalLayout_6.addItem(self.verticalSpacer_4)
+        self.verticalLayout_10.addItem(self.verticalSpacer_4)
 
 
-        self.horizontalLayout_14.addLayout(self.verticalLayout_6)
+        self.horizontalLayout_14.addLayout(self.verticalLayout_10)
+
+        self.verticalLayout_11 = QVBoxLayout()
+        self.verticalLayout_11.setObjectName(u"verticalLayout_11")
+        self.custom_model_preview_label = QLabel(self.tab_player_customization)
+        self.custom_model_preview_label.setObjectName(u"custom_model_preview_label")
+
+        self.verticalLayout_11.addWidget(self.custom_model_preview_label)
+
+        self.verticalSpacer_5 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+
+        self.verticalLayout_11.addItem(self.verticalSpacer_5)
 
 
-        self.verticalLayout_3.addLayout(self.horizontalLayout_14)
+        self.horizontalLayout_14.addLayout(self.verticalLayout_11)
+
+
+        self.verticalLayout_9.addLayout(self.horizontalLayout_14)
 
         self.tabWidget.addTab(self.tab_player_customization, "")
 
-        self.verticalLayout_4.addWidget(self.tabWidget)
+        self.verticalLayout_2.addWidget(self.tabWidget)
 
         self.scrollArea.setWidget(self.scrollAreaWidgetContents)
 
@@ -856,6 +882,20 @@ class Ui_MainWindow(object):
         self.progression_tingle_chests.setText(QCoreApplication.translate("MainWindow", u"Tingle Chests", None))
         self.progression_island_puzzles.setText(QCoreApplication.translate("MainWindow", u"Island Puzzles", None))
         self.groupBox_2.setTitle(QCoreApplication.translate("MainWindow", u"Additional Randomization Options", None))
+        self.label_for_sword_mode.setText(QCoreApplication.translate("MainWindow", u"Sword Mode", None))
+        self.sword_mode.setItemText(0, QCoreApplication.translate("MainWindow", u"Start with Hero's Sword", None))
+        self.sword_mode.setItemText(1, QCoreApplication.translate("MainWindow", u"No Starting Sword", None))
+        self.sword_mode.setItemText(2, QCoreApplication.translate("MainWindow", u"Swordless", None))
+
+        self.label_for_randomize_entrances.setText(QCoreApplication.translate("MainWindow", u"Randomize Entrances", None))
+        self.randomize_entrances.setItemText(0, QCoreApplication.translate("MainWindow", u"Disabled", None))
+        self.randomize_entrances.setItemText(1, QCoreApplication.translate("MainWindow", u"Dungeons", None))
+        self.randomize_entrances.setItemText(2, QCoreApplication.translate("MainWindow", u"Secret Caves", None))
+        self.randomize_entrances.setItemText(3, QCoreApplication.translate("MainWindow", u"Dungeons & Secret Caves (Separately)", None))
+        self.randomize_entrances.setItemText(4, QCoreApplication.translate("MainWindow", u"Dungeons & Secret Caves (Together)", None))
+
+        self.keylunacy.setText(QCoreApplication.translate("MainWindow", u"Key-Lunacy", None))
+        self.chest_type_matches_contents.setText(QCoreApplication.translate("MainWindow", u"Chest Type Matches Contents", None))
         self.label_for_num_starting_triforce_shards.setText(QCoreApplication.translate("MainWindow", u"Triforce Shards to Start With", None))
         self.num_starting_triforce_shards.setItemText(0, QCoreApplication.translate("MainWindow", u"0", None))
         self.num_starting_triforce_shards.setItemText(1, QCoreApplication.translate("MainWindow", u"1", None))
@@ -867,52 +907,21 @@ class Ui_MainWindow(object):
         self.num_starting_triforce_shards.setItemText(7, QCoreApplication.translate("MainWindow", u"7", None))
         self.num_starting_triforce_shards.setItemText(8, QCoreApplication.translate("MainWindow", u"8", None))
 
+        self.randomize_charts.setText(QCoreApplication.translate("MainWindow", u"Randomize Charts", None))
+        self.randomize_music.setText(QCoreApplication.translate("MainWindow", u"Randomize Music", None))
+        self.randomize_enemies.setText(QCoreApplication.translate("MainWindow", u"Randomize Enemy Locations", None))
         self.randomize_starting_island.setText(QCoreApplication.translate("MainWindow", u"Randomize Starting Island", None))
         self.randomize_enemy_palettes.setText(QCoreApplication.translate("MainWindow", u"Randomize Enemy Palettes", None))
-        self.randomize_music.setText(QCoreApplication.translate("MainWindow", u"Randomize Music", None))
-        self.label_for_sword_mode.setText(QCoreApplication.translate("MainWindow", u"Sword Mode", None))
-        self.sword_mode.setItemText(0, QCoreApplication.translate("MainWindow", u"Start with Hero's Sword", None))
-        self.sword_mode.setItemText(1, QCoreApplication.translate("MainWindow", u"No Starting Sword", None))
-        self.sword_mode.setItemText(2, QCoreApplication.translate("MainWindow", u"Swordless", None))
-
-        self.randomize_enemies.setText(QCoreApplication.translate("MainWindow", u"Randomize Enemy Locations", None))
-        self.chest_type_matches_contents.setText(QCoreApplication.translate("MainWindow", u"Chest Type Matches Contents", None))
-        self.randomize_charts.setText(QCoreApplication.translate("MainWindow", u"Randomize Charts", None))
-        self.race_mode.setText(QCoreApplication.translate("MainWindow", u"Race Mode", None))
-        self.label_for_num_race_mode_dungeons.setText(QCoreApplication.translate("MainWindow", u"Race Mode Required Dungeons", None))
-        self.num_race_mode_dungeons.setItemText(0, QCoreApplication.translate("MainWindow", u"1", None))
-        self.num_race_mode_dungeons.setItemText(1, QCoreApplication.translate("MainWindow", u"2", None))
-        self.num_race_mode_dungeons.setItemText(2, QCoreApplication.translate("MainWindow", u"3", None))
-        self.num_race_mode_dungeons.setItemText(3, QCoreApplication.translate("MainWindow", u"4", None))
-        self.num_race_mode_dungeons.setItemText(4, QCoreApplication.translate("MainWindow", u"5", None))
-        self.num_race_mode_dungeons.setItemText(5, QCoreApplication.translate("MainWindow", u"6", None))
-
-        self.keylunacy.setText(QCoreApplication.translate("MainWindow", u"Key-Lunacy", None))
-        self.label_for_randomize_entrances.setText(QCoreApplication.translate("MainWindow", u"Randomize Entrances", None))
-        self.randomize_entrances.setItemText(0, QCoreApplication.translate("MainWindow", u"Disabled", None))
-        self.randomize_entrances.setItemText(1, QCoreApplication.translate("MainWindow", u"Dungeons", None))
-        self.randomize_entrances.setItemText(2, QCoreApplication.translate("MainWindow", u"Secret Caves", None))
-        self.randomize_entrances.setItemText(3, QCoreApplication.translate("MainWindow", u"Dungeons & Secret Caves (Separately)", None))
-        self.randomize_entrances.setItemText(4, QCoreApplication.translate("MainWindow", u"Dungeons & Secret Caves (Together)", None))
-
-        self.groupBox_3.setTitle(QCoreApplication.translate("MainWindow", u"Hint Options", None))
-        self.fishmen_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Fishmen", None))
-        self.hoho_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Old Man Ho Ho", None))
-        self.label_for_num_hints.setText(QCoreApplication.translate("MainWindow", u"Hint Count", None))
-        self.korl_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on King of Red Lions", None))
-        self.groupBox_4.setTitle(QCoreApplication.translate("MainWindow", u"Convenience Tweaks", None))
-        self.remove_title_and_ending_videos.setText(QCoreApplication.translate("MainWindow", u"Remove Title and Ending Videos", None))
-        self.instant_text_boxes.setText(QCoreApplication.translate("MainWindow", u"Instant Text Boxes", None))
-        self.swift_sail.setText(QCoreApplication.translate("MainWindow", u"Swift Sail", None))
-        self.invert_sea_compass_x_axis.setText(QCoreApplication.translate("MainWindow", u"Invert Sea Compass X-Axis", None))
-        self.remove_music.setText(QCoreApplication.translate("MainWindow", u"Remove Music", None))
+        self.groupBox_3.setTitle(QCoreApplication.translate("MainWindow", u"Convenience Tweaks", None))
         self.invert_camera_x_axis.setText(QCoreApplication.translate("MainWindow", u"Invert Camera X-Axis", None))
+        self.swift_sail.setText(QCoreApplication.translate("MainWindow", u"Swift Sail", None))
+        self.remove_music.setText(QCoreApplication.translate("MainWindow", u"Remove Music", None))
         self.reveal_full_sea_chart.setText(QCoreApplication.translate("MainWindow", u"Reveal Full Sea Chart", None))
-        self.add_shortcut_warps_between_dungeons.setText(QCoreApplication.translate("MainWindow", u"Add Shortcut Warps Between Dungeons", None))
+        self.instant_text_boxes.setText(QCoreApplication.translate("MainWindow", u"Instant Text Boxes", None))
+        self.remove_title_and_ending_videos.setText(QCoreApplication.translate("MainWindow", u"Remove Title and Ending Videos", None))
         self.skip_rematch_bosses.setText(QCoreApplication.translate("MainWindow", u"Skip Boss Rematches", None))
-        self.groupBox_5.setTitle(QCoreApplication.translate("MainWindow", u"Advanced Options", None))
-        self.disable_tingle_chests_with_tingle_bombs.setText(QCoreApplication.translate("MainWindow", u"Tingle Bombs Don't Open Tingle Chests", None))
-        self.do_not_generate_spoiler_log.setText(QCoreApplication.translate("MainWindow", u"Do Not Generate Spoiler Log", None))
+        self.add_shortcut_warps_between_dungeons.setText(QCoreApplication.translate("MainWindow", u"Add Shortcut Warps Between Dungeons", None))
+        self.invert_sea_compass_x_axis.setText(QCoreApplication.translate("MainWindow", u"Invert Sea Compass X-Axis", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_randomizer_settings), QCoreApplication.translate("MainWindow", u"Randomizer Settings", None))
         self.label_for_randomized_gear.setText(QCoreApplication.translate("MainWindow", u"Randomized Gear", None))
         self.remove_gear.setText(QCoreApplication.translate("MainWindow", u"<-", None))
@@ -922,6 +931,25 @@ class Ui_MainWindow(object):
         self.label_for_starting_pohs.setText(QCoreApplication.translate("MainWindow", u"Heart Pieces", None))
         self.current_health.setText(QCoreApplication.translate("MainWindow", u"Current Starting Health: 3 hearts", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_starting_items), QCoreApplication.translate("MainWindow", u"Starting Items", None))
+        self.groupBox_4.setTitle(QCoreApplication.translate("MainWindow", u"Race Mode Options", None))
+        self.race_mode.setText(QCoreApplication.translate("MainWindow", u"Race Mode", None))
+        self.label_for_num_race_mode_dungeons.setText(QCoreApplication.translate("MainWindow", u"Race Mode Required Dungeons", None))
+        self.num_race_mode_dungeons.setItemText(0, QCoreApplication.translate("MainWindow", u"1", None))
+        self.num_race_mode_dungeons.setItemText(1, QCoreApplication.translate("MainWindow", u"2", None))
+        self.num_race_mode_dungeons.setItemText(2, QCoreApplication.translate("MainWindow", u"3", None))
+        self.num_race_mode_dungeons.setItemText(3, QCoreApplication.translate("MainWindow", u"4", None))
+        self.num_race_mode_dungeons.setItemText(4, QCoreApplication.translate("MainWindow", u"5", None))
+        self.num_race_mode_dungeons.setItemText(5, QCoreApplication.translate("MainWindow", u"6", None))
+
+        self.groupBox_5.setTitle(QCoreApplication.translate("MainWindow", u"Hint Options", None))
+        self.fishmen_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Fishmen", None))
+        self.hoho_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Old Man Ho Ho", None))
+        self.label_for_num_hints.setText(QCoreApplication.translate("MainWindow", u"Hint Count", None))
+        self.korl_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on King of Red Lions", None))
+        self.groupBox_6.setTitle(QCoreApplication.translate("MainWindow", u"Additional Advanced Options", None))
+        self.disable_tingle_chests_with_tingle_bombs.setText(QCoreApplication.translate("MainWindow", u"Tingle Bombs Don't Open Tingle Chests", None))
+        self.do_not_generate_spoiler_log.setText(QCoreApplication.translate("MainWindow", u"Do Not Generate Spoiler Log", None))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab), QCoreApplication.translate("MainWindow", u"Advanced Options", None))
         self.label_for_custom_color_preset.setText(QCoreApplication.translate("MainWindow", u"Color Preset", None))
         self.randomize_all_custom_colors_together.setText(QCoreApplication.translate("MainWindow", u"Randomize Colors Orderly", None))
         self.randomize_all_custom_colors_separately.setText(QCoreApplication.translate("MainWindow", u"Randomize Colors Chaotically", None))


### PR DESCRIPTION
This PR adds King of Red Lions as an alternative hint placement option.

The current hint placement options available to the player are the fishmen and Old Man Ho Ho. Both these options share that the player must go out of their way to get these hints, sometimes extremely so. For example, the player might get the Bait Bag for fishmen hints late into the seed, lessening the usefulness of hints. Additionally, these hint placement options can be tricky to use competitively. For example, one runner might go far out of their way to talk to an Old Man Ho Ho but get rewarded with no helpful information. Or the opposite could happen where this risky venture gives the runner valuable information as to where an item like Light Arrows are. Some might find that desirable, but I would argue that a more fair hint placement option should be available.

As a hint placement option, King of Red Lions (KoRL) addresses these issues because the player can talk to KoRL at almost any point during the seed. Additionally, since KoRL gives all the hints, all runners in a race are working with the same information at the same time. This means that hints can be used to guide the player's routing without introducing the routing risk of actually getting the hints. Of course, how a player uses the information from hints introduces risk. Still, I would argue that this is the intended application of having hints in a randomizer.

Since KoRL tells the player all the hints, he has one textbox for every hint assigned to the hint placement option. Therefore, we remove the delay for KoRL's textboxes, typically added to hint text to stop the player from passing over a hint. This change reflects community feedback on KoRL hints. It lessens the time loss accrued when accidentally talking to KoRL, which can happen multiple times per seed. Additionally, since talking to KoRL is very accessible, if a player does skip over a hint, talking to KoRL again is not punishing.