### PR TITLE
Add mode for zoomed out ratio

### DIFF
--- a/asm/patches/open_matte_mode
+++ b/asm/patches/open_matte_mode
@@ -1,0 +1,24 @@
+; Renders the scene in a, rather than usual, open matte aspect ratio.
+.open "sys/main.dol"
+.org 0x8017C1F4 ; Fovy stored in store__FP20camera_process_class
+  b readjust_fovy
+ ; Zoom the camera's fov angle for an old fashioned screen.
+.org @NextFreeSpace
+.global readjust_fovy
+readjust_fovy:
+  lfs f1, -0x3F3C (rtoc) ; Load the half multiplier to divide the degress in preperation to calculate tangent.
+  fmuls f1, f31, f1 ; Multiply angle in half.
+  lfs f31, -0x3F40 (rtoc) ; Convert angle to radians.
+  fmuls f1, f31, f1
+  bl tan
+  lfs f31, -0x7D9C (rtoc)
+  fdivs f1, f1, f31 ; Scale fovy tangent.
+  bl atan
+  fadds f1, f1, f1 ; Multiply the resulting angle back to full rads.
+  lfs f31, -0x3F40 (rtoc) ; Convert back to degress.
+  fdivs f31, f1, f31,
+  stfs f31, 0xD0 (r28) ; Store the calculated fov to the camera pointer.
+  
+  b 0x8017C1F8 ; Return
+  
+.close


### PR DESCRIPTION
Giving Wind Waker an nice open matte screen, the screenshots below show proof how the screen would render with this patch.

Before:
![GZLE01_2022-09-05_00-08-46](https://user-images.githubusercontent.com/30204050/188386506-06440a16-78a8-4daa-938d-c2fd8b5ade0c.png)
After:
![GZLE01_2022-09-05_00-08-32](https://user-images.githubusercontent.com/30204050/188386343-194ea2fc-6715-4fb6-9a19-4ba2fff2154f.png)
