### PR TITLE
Enemy randomizer - difficulty settings

### DIFF
--- a/data/enemy_types.txt
+++ b/data/enemy_types.txt
@@ -298,7 +298,7 @@
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
   # Note: Cannot escape from a Dexivine that catches you without some weapon to cut it down.
-  Difficulty: [Very Hard Enemies, Fully Random Enemies]
+  Difficulty: [Very Hard Enemies, Fully Random Enemies] # Very Hard due to potential to softlock the player, requiring a restart to escape.
 -
   Pretty name: Keese
   Actor name: keeth
@@ -398,7 +398,7 @@
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
-  Difficulty: [Very Hard Enemies, Fully Random Enemies]
+  Difficulty: [Very Hard Enemies, Fully Random Enemies] # Very Hard due to becoming spammy when replacing a group of single enemies
 -
   Pretty name: Wizzrobe
   Actor name: wiz_r
@@ -680,7 +680,7 @@
   Allow near pits: True # Dies instantly when over a pit. In vanilla it didn't set its death switch but this was fixed.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
-  Difficulty: [Very Hard Enemies, Fully Random Enemies]
+  Difficulty: [Very Hard Enemies, Fully Random Enemies] # Very Hard due to high damage, high hp, and difficulty in close quarters/with a lot of them
 -
   Pretty name: Boko Baba
   Actor name: bbaba
@@ -780,7 +780,7 @@
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
-  Difficulty: [Very Hard Enemies, Fully Random Enemies]
+  Difficulty: [Very Hard Enemies, Fully Random Enemies] # Very Hard due to combo with other enemies by preventing your sword, and high requirements to kill.
 -
   Pretty name: Inanimate Bubble
   Actor name: bable
@@ -800,7 +800,7 @@
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
-  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
+  Difficulty: [Easy Enemies, Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Wingless Mothula
   Actor name: gmos
@@ -944,7 +944,7 @@
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No # Floormasters actually can be killed by bombs but this is annoying to do.
-  Difficulty: [Very Hard Enemies, Fully Random Enemies]
+  Difficulty: [Very Hard Enemies, Fully Random Enemies] # Very Hard due to how punishing it is of mistakes - it forces a room restart.
 -
   Pretty name: Floormaster
   Actor name: Fmastr2
@@ -964,4 +964,4 @@
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No # Floormasters actually can be killed by bombs but this is annoying to do.
-  Difficulty: [Very Hard Enemies, Fully Random Enemies]
+  Difficulty: [Very Hard Enemies, Fully Random Enemies] # Very Hard due to how punishing it is of mistakes - it forces a room restart.

--- a/data/enemy_types.txt
+++ b/data/enemy_types.txt
@@ -10,13 +10,14 @@
   Allow randomizing to: True
   Placement categories: [Ground, Pot]
   Memory used by first one: 53280
-  Memory used by subequent ones: 23088
+  Memory used by subsequent ones: 23088
   Enable spawn switch param name: spawn_condition_switch
   Death switch param name: disable_spawn_on_death_switch
   Path param name: path_index
   Allow near pits: True # Dies when falling in pits, but properly sets it death switch, so we allow it.
   Can be killed with thrown objects: Yes # 3 hits
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Green ChuChu
   Actor name: c_green
@@ -29,13 +30,14 @@
   Allow randomizing to: True
   Placement categories: [Ground, Pot, Ceiling]
   Memory used by first one: 31904
-  Memory used by subequent ones: 18496
+  Memory used by subsequent ones: 18496
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK (they can jump off while trying to attack the player, but don't by themselves. do they die in the pit, or still count as a living enemy?)
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Red ChuChu
   Actor name: c_red
@@ -48,13 +50,14 @@
   Allow randomizing to: True
   Placement categories: [Ground, Pot, Ceiling]
   Memory used by first one: 31904
-  Memory used by subequent ones: 18496
+  Memory used by subsequent ones: 18496
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Yellow ChuChu
   Actor name: c_kiiro
@@ -67,13 +70,14 @@
   Allow randomizing to: True
   Placement categories: [Ground, Pot, Ceiling]
   Memory used by first one: 31904
-  Memory used by subequent ones: 18496
+  Memory used by subsequent ones: 18496
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Blue ChuChu
   Actor name: c_blue
@@ -86,13 +90,14 @@
   Allow randomizing to: False # Randomizing to them would allow you to get Blue Chu Jelly more easily than in vanilla.
   Placement categories: [Ground, Pot, Ceiling]
   Memory used by first one: 31904
-  Memory used by subequent ones: 18496
+  Memory used by subsequent ones: 18496
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Dark ChuChu
   Actor name: c_black
@@ -105,13 +110,14 @@
   Allow randomizing to: False # Can't be randomized since there would be no light ray to petrify it.
   Placement categories: [Ground, Pot, Ceiling]
   Memory used by first one: 31904
-  Memory used by subequent ones: 18496
+  Memory used by subsequent ones: 18496
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Kargaroc
   Actor name: Bb
@@ -124,13 +130,14 @@
   Allow randomizing to: True
   Placement categories: [Air, Ground, Ceiling]
   Memory used by first one: 49120
-  Memory used by subequent ones: 41024
+  Memory used by subsequent ones: 41024
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: path_index
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Lantern Moblin
   Actor name: mo2
@@ -143,13 +150,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 105088
-  Memory used by subequent ones: 66400
+  Memory used by subsequent ones: 66400
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: disable_spawn_on_death_switch
   Path param name: path_index
   Allow near pits: True # Dies instantly when over a pit. In vanilla it didn't set its death switch but this was fixed.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Blue Moblin
   Actor name: mo2
@@ -162,13 +170,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 60512
-  Memory used by subequent ones: 36112
+  Memory used by subsequent ones: 36112
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: disable_spawn_on_death_switch
   Path param name: path_index
   Allow near pits: True # Dies instantly when over a pit. In vanilla it didn't set its death switch but this was fixed.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Peahat
   Actor name: p_hat
@@ -181,13 +190,14 @@
   Allow randomizing to: True
   Placement categories: [Air, Ceiling]
   Memory used by first one: 14688
-  Memory used by subequent ones: 10208
+  Memory used by subsequent ones: 10208
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: disable_spawn_on_death_switch
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Seahat
   Actor name: p_hat
@@ -200,13 +210,14 @@
   Allow randomizing to: True
   Placement categories: [Sea]
   Memory used by first one: 23872
-  Memory used by subequent ones: 16096
+  Memory used by subsequent ones: 16096
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Armos Knight
   Actor name: amos
@@ -219,13 +230,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 13152
-  Memory used by subequent ones: 7456
+  Memory used by subsequent ones: 7456
   Enable spawn switch param name: spawn_condition_switch
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Armos
   Actor name: amos2
@@ -238,13 +250,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 11840
-  Memory used by subequent ones: 6976
+  Memory used by subsequent ones: 6976
   Enable spawn switch param name: spawn_condition_switch
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Inanimate Armos
   Actor name: amos2
@@ -257,13 +270,14 @@
   Allow randomizing to: False
   Placement categories: [Ground]
   Memory used by first one: 11840
-  Memory used by subequent ones: 6976
+  Memory used by subsequent ones: 6976
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Easy Enemies, Fully Random Enemies]
 -
   Pretty name: Dexivine
   Actor name: Sss
@@ -276,7 +290,7 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 7744
-  Memory used by subequent ones: 6976
+  Memory used by subsequent ones: 6976
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: null
@@ -284,6 +298,7 @@
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
   # Note: Cannot escape from a Dexivine that catches you without some weapon to cut it down.
+  Difficulty: [Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Keese
   Actor name: keeth
@@ -296,13 +311,14 @@
   Allow randomizing to: True
   Placement categories: [Air, Ceiling]
   Memory used by first one: 15744
-  Memory used by subequent ones: 6016
+  Memory used by subsequent ones: 6016
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: path_index
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # 1 hit
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Fire Keese
   Actor name: Fkeeth
@@ -315,13 +331,14 @@
   Allow randomizing to: False # We will place these, but just by randomizing the parameters on regular Keese instead.
   Placement categories: [Air, Ceiling]
   Memory used by first one: 17376
-  Memory used by subequent ones: 7648
+  Memory used by subsequent ones: 7648
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: path_index
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Freshwater Octorok
   Actor name: Oq
@@ -334,13 +351,14 @@
   Allow randomizing to: True
   Placement categories: [Water]
   Memory used by first one: 28640
-  Memory used by subequent ones: 11936
+  Memory used by subsequent ones: 11936
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Saltwater Octorok
   Actor name: Oqw
@@ -353,13 +371,14 @@
   Allow randomizing to: True
   Placement categories: [Sea]
   Memory used by first one: 34784
-  Memory used by subequent ones: 18080
+  Memory used by subsequent ones: 18080
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Saltwater Octorok Spawner
   Actor name: Oqw
@@ -372,13 +391,14 @@
   Allow randomizing to: True
   Placement categories: [Sea]
   Memory used by first one: 112784
-  Memory used by subequent ones: 93888
+  Memory used by subsequent ones: 93888
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Wizzrobe
   Actor name: wiz_r
@@ -391,13 +411,14 @@
   Allow randomizing to: True
   Placement categories: [Ground, StationaryAir]
   Memory used by first one: 65712 # 25440 without the fireballs being spawned
-  Memory used by subequent ones: 54224 # 13536 without the fireballs being spawned
+  Memory used by subsequent ones: 54224 # 13536 without the fireballs being spawned
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: disable_spawn_on_death_switch
   Path param name: path_index
   Allow near pits: True
   Can be killed with thrown objects: Yes # Takes two pots to kill.
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: ReDead
   Actor name: Rdead1
@@ -410,13 +431,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 14272
-  Memory used by subequent ones: 9664
+  Memory used by subsequent ones: 9664
   Enable spawn switch param name: enable_spawn_switch # Also needs dont_check_enable_spawn_switch to be set to 0
   Death switch param name: disable_spawn_on_death_switch # Param added by the randomizer
   Path param name: null
   Allow near pits: True # TODO CHECK (note that if they fall down a small ledge, they keep trying to return to their spawn point but can't because it's high up now)
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Sitting ReDead
   Actor name: Rdead2
@@ -429,13 +451,14 @@
   Allow randomizing to: False # We will place these, but just by randomizing the parameters on regular ReDeads instead.
   Placement categories: [Ground]
   Memory used by first one: 14272
-  Memory used by subequent ones: 9664
+  Memory used by subsequent ones: 9664
   Enable spawn switch param name: enable_spawn_switch # Also needs dont_check_enable_spawn_switch to be set to 0
   Death switch param name: disable_spawn_on_death_switch # Param added by the randomizer
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Poe
   Actor name: pow
@@ -448,13 +471,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 59712
-  Memory used by subequent ones: 39984
+  Memory used by subsequent ones: 39984
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: path_index
   Allow near pits: False # If they happen to go over the edge, they float down into the pit and don't come back up. (e.g. in Cave01/Room1)
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Chasing Morth
   Actor name: kuro_s
@@ -467,13 +491,14 @@
   Allow randomizing to: True
   Placement categories: [Ground, Pot]
   Memory used by first one: 44896 # For 10 Morths.
-  Memory used by subequent ones: 43520 # For 10 Morths.
+  Memory used by subsequent ones: 43520 # For 10 Morths.
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: False
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
   # Note: These don't count as being alive, if only morths are in a room the room will consider itself completed immediately.
 -
   Pretty name: Morth
@@ -487,7 +512,7 @@
   Allow randomizing to: True
   Placement categories: [Ground, Pot]
   Memory used by first one: 44896 # For 10 Morths.
-  Memory used by subequent ones: 43520 # For 10 Morths.
+  Memory used by subsequent ones: 43520 # For 10 Morths.
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
@@ -495,6 +520,7 @@
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
   # Note: These don't count as being alive, if only morths are in a room the room will consider itself completed immediately.
+  Difficulty: [Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Miniblin
   Actor name: Puti
@@ -507,13 +533,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 7904
-  Memory used by subequent ones: 5312
+  Memory used by subsequent ones: 5312
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null # TODO irregular_switch acts as this for single miniblins, but it's buggy for permanent switches. perhaps we could make use of it, but replace the switch that's set with a temporary switch...?
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # 1 hit
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Rat
   Actor name: nezumi
@@ -526,13 +553,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 24512
-  Memory used by subequent ones: 12960
+  Memory used by subsequent ones: 12960
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: False # Rats run off by themselves, often before the player even sees them.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Bombchu
   Actor name: nezumi
@@ -545,13 +573,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 26944
-  Memory used by subequent ones: 15392
+  Memory used by subsequent ones: 15392
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: False # Rats run off by themselves, often before the player even sees them.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Easy Enemies, Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Rat Hole
   Actor name: nezuana
@@ -564,13 +593,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 99136 # For 5 rats, also includes the rat shopkeeper.
-  Memory used by subequent ones: 79040 # For 5 rats, also includes the rat shopkeeper.
+  Memory used by subsequent ones: 79040 # For 5 rats, also includes the rat shopkeeper.
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: False # Rats run off by themselves, often before the player even sees them.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Bombchu Hole
   Actor name: nezuana
@@ -583,13 +613,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 92128 # For 5 Bombchus.
-  Memory used by subequent ones: 78784 # For 5 Bombchus.
+  Memory used by subsequent ones: 78784 # For 5 Bombchus.
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: False # Rats run off by themselves, often before the player even sees them.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Rat and Bombchu Hole
   Actor name: nezuana
@@ -602,13 +633,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 92128 # For 5 rats/Bombchus.
-  Memory used by subequent ones: 78784 # For 5 rats/Bombchus.
+  Memory used by subsequent ones: 78784 # For 5 rats/Bombchus.
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: False # Rats run off by themselves, often before the player even sees them.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Stalfos
   Actor name: Stal
@@ -621,13 +653,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 93536
-  Memory used by subequent ones: 42064
+  Memory used by subsequent ones: 42064
   Enable spawn switch param name: ambush_switch # Also needs type to be set to 1 for underground (or 2/3 for in a coffin)
   Death switch param name: disable_spawn_on_death_switch
   Path param name: null
   Allow near pits: True # Dies instantly when over a pit. In vanilla it didn't set its death switch but this was fixed. TODO: Still doesn't die in lava pits though.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Darknut
   Actor name: Tn
@@ -640,13 +673,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 109296
-  Memory used by subequent ones: 73920
+  Memory used by subsequent ones: 73920
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: disable_spawn_on_death_switch
   Path param name: path_index
   Allow near pits: True # Dies instantly when over a pit. In vanilla it didn't set its death switch but this was fixed.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Boko Baba
   Actor name: bbaba
@@ -659,13 +693,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 20288
-  Memory used by subequent ones: 12704
+  Memory used by subsequent ones: 12704
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: No # Needs 2 hits, but it's not possible to throw the second one fast enough
   Can be killed with bomb flowers: Yes
+  Difficulty: [Easy Enemies, Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Boko Bud Boko Baba
   Actor name: bbaba
@@ -678,13 +713,14 @@
   Allow randomizing to: False
   Placement categories: [Ground]
   Memory used by first one: 20288
-  Memory used by subequent ones: 12704
+  Memory used by subsequent ones: 12704
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Magtail
   Actor name: magtail
@@ -697,13 +733,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 80896
-  Memory used by subequent ones: 56512
+  Memory used by subsequent ones: 56512
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: disable_spawn_on_death_switch
   Path param name: path_index
   Allow near pits: False # If it falls in the sea, it dies, but doesn't set its death switch. TODO: try to code it to set that properly. also TODO: I assume these work in lava pits? if so, I may need to separate lava vs sea pits into separate conditions.
   Can be killed with thrown objects: No # They do take damage from thrown objects, but it's annoying to hit them and just two objects isn't enough to kill it, so don't make this required.
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Red Bubble
   Actor name: bable
@@ -716,13 +753,14 @@
   Allow randomizing to: True
   Placement categories: [Ground, Air, Ceiling]
   Memory used by first one: 7936
-  Memory used by subequent ones: 5504
+  Memory used by subsequent ones: 5504
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: path_index
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: No
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Fully Random Enemies]
 -
   Pretty name: Blue Bubble
   Actor name: bable
@@ -735,13 +773,14 @@
   Allow randomizing to: True
   Placement categories: [Ground, Air, Ceiling]
   Memory used by first one: 7936
-  Memory used by subequent ones: 5504
+  Memory used by subsequent ones: 5504
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: path_index
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Inanimate Bubble
   Actor name: bable
@@ -754,13 +793,14 @@
   Allow randomizing to: False
   Placement categories: [Ground]
   Memory used by first one: 7936
-  Memory used by subequent ones: 5504
+  Memory used by subsequent ones: 5504
   Enable spawn switch param name: null
   Death switch param name: null
   Path param name: null
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Wingless Mothula
   Actor name: gmos
@@ -773,13 +813,14 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 133200 # This includes the maximum of 10 spawned morths
-  Memory used by subequent ones: 68896
+  Memory used by subsequent ones: 68896
   Enable spawn switch param name: null
   Death switch param name: disable_spawn_on_death_switch
   Path param name: null
   Allow near pits: False # They don't die in pits.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Winged Mothula
   Actor name: gmos
@@ -792,13 +833,14 @@
   Allow randomizing to: True
   Placement categories: [Air, Ceiling]
   Memory used by first one: 148272 # This includes the maximum of 20 spawned morths + 1 falling wing
-  Memory used by subequent ones: 111792
+  Memory used by subsequent ones: 111792
   Enable spawn switch param name: null
   Death switch param name: disable_spawn_on_death_switch
   Path param name: null
   Allow near pits: False # They turn into wingless ones, which then don't die in pits.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
+  Difficulty: [Fully Random Enemies] # TODO
 -
   Pretty name: Cross-Sector Gyorg Spawner
   Actor name: GyCtrl
@@ -811,13 +853,14 @@
   Allow randomizing to: False # Don't risk memory issues by letting enemies go across sectors.
   Placement categories: [Sea]
   Memory used by first one: 106576 # For 5 Gyorgs.
-  Memory used by subequent ones: 88736 # For 5 Gyorgs.
+  Memory used by subsequent ones: 88736 # For 5 Gyorgs.
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: null
   Allow near pits: True
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Gyorg Spawner
   Actor name: GyCtrlB
@@ -830,13 +873,14 @@
   Allow randomizing to: True
   Placement categories: [Sea]
   Memory used by first one: 106576 # For 5 Gyorgs.
-  Memory used by subequent ones: 88736 # For 5 Gyorgs.
+  Memory used by subsequent ones: 88736 # For 5 Gyorgs.
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: null
   Allow near pits: True
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No
+  Difficulty: [Easy Enemies, Medium Enemies, Hard Enemies, Very Hard Enemies, Fully Random Enemies]
 #-
 #  Pretty name: Blue Beamos
 #  Actor name: Hmos1
@@ -893,13 +937,14 @@
   Allow randomizing to: False # It wouldn't have a path to follow so it would go to some weird spot
   Placement categories: [Ground]
   Memory used by first one: 12608
-  Memory used by subequent ones: 8608
+  Memory used by subsequent ones: 8608
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: path_index
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No # Floormasters actually can be killed by bombs but this is annoying to do.
+  Difficulty: [Very Hard Enemies, Fully Random Enemies]
 -
   Pretty name: Floormaster
   Actor name: Fmastr2
@@ -912,10 +957,11 @@
   Allow randomizing to: True
   Placement categories: [Ground]
   Memory used by first one: 12608
-  Memory used by subequent ones: 8608
+  Memory used by subsequent ones: 8608
   Enable spawn switch param name: enable_spawn_switch
   Death switch param name: null
   Path param name: path_index
   Allow near pits: True # TODO CHECK
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: No # Floormasters actually can be killed by bombs but this is annoying to do.
+  Difficulty: [Very Hard Enemies, Fully Random Enemies]

--- a/data/enemy_types.txt
+++ b/data/enemy_types.txt
@@ -840,7 +840,7 @@
   Allow near pits: False # They turn into wingless ones, which then don't die in pits.
   Can be killed with thrown objects: Yes # TODO CHECK
   Can be killed with bomb flowers: Yes
-  Difficulty: [Fully Random Enemies] # TODO
+  Difficulty: [Fully Random Enemies] # Note - Winged Mothula consumes too much memory to be usable in many rooms, and so adding to Very Hard option causes failure to randomize.
 -
   Pretty name: Cross-Sector Gyorg Spawner
   Actor name: GyCtrl

--- a/randomizer.py
+++ b/randomizer.py
@@ -425,9 +425,11 @@ class Randomizer:
     
     # Enemies must be randomized before items in order for the enemy logic to properly take into account what items you do and don't start with.
     if self.options.get("randomize_enemies"):
-      yield("Randomizing enemy locations...", options_completed)
+      if self.options.get("randomize_enemies_difficulty") != "Fully Random Enemies" and self.options.get("progression_spoils_trading"):
+        raise Exception("Enemy randomizer difficulty (besides \"Fully Random Enemies\") is incompatible with Spoils Trading in logic.")
+      yield ("Randomizing enemy locations...", options_completed)
       self.reset_rng()
-      enemies.randomize_enemies(self)
+      enemies.randomize_enemies(self, self.options.get("randomize_enemies_difficulty"))
     
     if self.options.get("randomize_enemy_palettes"):
       yield("Randomizing enemy colors...", options_completed)

--- a/randomizers/enemies.py
+++ b/randomizers/enemies.py
@@ -62,7 +62,7 @@ STAGE_NAMES_WHERE_MULTIPLE_ROOMS_CAN_BE_LOADED_AT_ONCE = [
   "TF_06",
 ]
 
-def randomize_enemies(self):
+def randomize_enemies(self, difficulty):
   self.enemy_locations = Logic.load_and_parse_enemy_locations()
   
   # We must compile the human-written placement categories each enemy type is allowed in to account for extra category limitations (like locations where the enemy is required to set a switch on death).
@@ -75,6 +75,7 @@ def randomize_enemies(self):
   self.enemies_to_randomize_to = [
     data for data in self.enemy_types
     if data["Allow randomizing to"]
+    and difficulty in data["Difficulty"]
   ]
   self.enemies_to_randomize_to_when_all_enemies_must_be_killed = [
     data for data in self.enemy_types
@@ -83,6 +84,7 @@ def randomize_enemies(self):
     and "Morth" not in data["Pretty name"]
     # Also ban Dexivines because they can't actually be killed.
     and data["Pretty name"] != "Dexivine"
+    and difficulty in data["Difficulty"]
   ]
   
   self.enemy_datas_by_pretty_name = {}
@@ -910,7 +912,7 @@ def is_enemy_allowed_in_placement_category(enemy_data, category):
 def get_amount_of_memory_for_enemy(enemy_data, enemy_actor_names_already_placed_in_room):
   # The first enemy of a species placed in a room uses more than the subsequent ones.
   if enemy_data["Actor name"] in enemy_actor_names_already_placed_in_room:
-    return enemy_data["Memory used by subequent ones"]
+    return enemy_data["Memory used by subsequent ones"]
   else:
     return enemy_data["Memory used by first one"]
 

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -236,6 +236,10 @@ OPTIONS = OrderedDict([
     "randomize_enemies",
     "Randomizes the placement of non-boss enemies."
   ),
+  (
+    "randomize_enemies_difficulty",
+    "How hard the random enemies will be."
+  ),
 ])
 
 NON_PERMALINK_OPTIONS = [
@@ -256,6 +260,12 @@ HIDDEN_OPTIONS = [
   "randomize_enemies",
 ]
 
+# Controls options that rely on another option being checked to be shown
+LINKED_HIDDEN_OPTIONS = [
+  ["randomize_enemies", "randomize_enemies_difficulty"]
+]
+
 POTENTIALLY_UNBEATABLE_OPTIONS = [
   "randomize_enemies",
+  "randomize_enemies_difficulty",
 ]

--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -3,7 +3,7 @@ from PySide6.QtCore import *
 from PySide6.QtWidgets import *
 
 from wwr_ui.ui_randomizer_window import Ui_MainWindow
-from wwr_ui.options import OPTIONS, NON_PERMALINK_OPTIONS, HIDDEN_OPTIONS, POTENTIALLY_UNBEATABLE_OPTIONS
+from wwr_ui.options import OPTIONS, NON_PERMALINK_OPTIONS, HIDDEN_OPTIONS, POTENTIALLY_UNBEATABLE_OPTIONS, LINKED_HIDDEN_OPTIONS
 from wwr_ui.update_checker import check_for_updates, LATEST_RELEASE_DOWNLOAD_PAGE_URL
 from wwr_ui.inventory import INVENTORY_ITEMS, REGULAR_ITEMS, PROGRESSIVE_ITEMS, DEFAULT_STARTING_ITEMS, DEFAULT_RANDOMIZED_ITEMS
 from wwr_ui.packedbits import PackedBitsReader, PackedBitsWriter
@@ -1035,6 +1035,14 @@ class WWRandomizerWindow(QMainWindow):
         widget.show()
       else:
         widget.hide()
+
+    # Hide certain options that rely on another option
+    for option_group in LINKED_HIDDEN_OPTIONS:
+      otherWidget = getattr(self.ui, option_group[1])
+      if(self.get_option_value(option_group[0])):
+        otherWidget.show()
+      else:
+        otherWidget.hide()
   
   def disable_invalid_cosmetic_options(self):
     custom_model_name = self.get_option_value("custom_player_model")

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -337,6 +337,17 @@ class Ui_MainWindow(object):
 
         self.gridLayout_3.addWidget(self.randomize_enemies, 2, 2, 1, 1)
 
+        self.randomize_enemies_difficulty = QComboBox(self.groupBox_2)
+        self.randomize_enemies_difficulty.addItem("Fully Random Enemies")
+        self.randomize_enemies_difficulty.addItem("Easy Enemies")
+        self.randomize_enemies_difficulty.addItem("Medium Enemies")
+        self.randomize_enemies_difficulty.addItem("Hard Enemies")
+        self.randomize_enemies_difficulty.addItem("Very Hard Enemies")
+        self.randomize_enemies_difficulty.setObjectName(u"randomize_enemies_difficulty")
+        self.randomize_enemies_difficulty.setLayoutDirection(Qt.LeftToRight)
+
+        self.gridLayout_3.addWidget(self.randomize_enemies_difficulty, 2, 3, 1, 1)
+
         self.randomize_starting_island = QCheckBox(self.groupBox_2)
         self.randomize_starting_island.setObjectName(u"randomize_starting_island")
 


### PR DESCRIPTION
Enemy randomizer often results in very difficult seeds due to placing combinations of enemies that weren't intended to be together in the main game. This pull request adds a "Difficulty" option to the enemy randomizer, to prevent hard enemies from spawning, or to make hard enemies spawn more.

The difficulties are:
- Fully random enemies: How the enemy randomizer works currently. Enemies are assigned purely at random.
- Easy enemies: Most enemies will be one-shots (keese, rats) or killed with one combo (bokoblins)
- Medium enemies: A combination of easy enemies and ones that require more effort, such as moblins/armos
- Hard enemies: Excludes the one-shot enemies, and adds enemies that are a serious threat such as Stalfos and ReDeads
- Very Hard enemies: The same as Hard, but includes enemies that can be unreasonable in large groups (Darknuts, Octorok Spawners), can cause softlock (Blue Bubble, Dexivine), or are extremely punishing of mistakes (Floormasters)

When any difficulty except "Fully Random Enemies" is enabled, the randomizer will not allow you to play with Spoils Trading progress items on, since certain enemies won't spawn on some difficulties, making farming spoils items impossible.

Flying Mothula are excluded from all difficulties and only spawned when playing on Fully Random Enemies mode. When Flying Mothulas are added to Very Hard, the randomizer often fails to generate a seed due to how much memory Flying Mothulas consume, together with not having low-memory enemies like Keese available to fill in the remainder.

Additionally, Flying Mothulas have infinite follow range which can cause problems in some places. They're also just frustrating to play against without Fire Arrows.

This PR also fixes a minor typo in the Enemy Randomizer data - subequent -> subsequent