### PR TITLE
Add three new hint types: Path, Barren, and Location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ settings.txt
 /models/*
 !/models/About Custom Models.txt
 /asm/maps-out
-profileresults.txt
+profileresults*.txt
 /keys/seed_key.py
 /keys/build_key.txt

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,18 @@
                 "-noui",
                 "-noitemrando",
             ],
+        },
+        {
+            "name": "Profile WWRando (No UI)",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/wwrando.py",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": [
+                "-noui",
+                "-profile",
+            ]
         }
     ]
 }

--- a/data/location_hints.txt
+++ b/data/location_hints.txt
@@ -82,7 +82,7 @@ Forest Haven - On Tree Branch:
   Text: receiving a gift from the Great Deku Tree
 Forest Haven - Small Island Chest:
   Type: Standard
-  Text: gliding to a remote island near a safe haven
+  Text: gliding to an isle behind the home of the woodland spirits
 
 Forbidden Woods - Mothula Mini-Boss Room:
   Type: Standard

--- a/data/location_hints.txt
+++ b/data/location_hints.txt
@@ -31,25 +31,25 @@ Windfall Island - Maggie's Father - Give 20 Skull Necklaces:
   Text: giving a wealthy man twenty necklaces
 Windfall Island - Zunari - Stock Exotic Flower in Zunari's Shop:
   Type: Sometimes
-  Text: stocking Zunari's shop with three flowers
+  Text: stocking a shop with three flowers
 Windfall Island - Sam - Decorate the Town:
   Type: Sometimes
   Text: volunteering to decorate Windfall
 Windfall Island - Mila - Follow the Thief:
   Type: Sometimes
-  Text: stopping a burglary of Zunari's safe
+  Text: preventing a burglary
 Windfall Island - Battlesquid - Under 20 Shots Prize:
   Type: Always
-  Text: setting a new high score in Battlesquid
+  Text: setting a new record in squid-shooting
 Windfall Island - Pompie and Vera - Secret Meeting Photo:
   Type: Sometimes
   Text: showing a photo to two gossiping ladies
 Windfall Island - Kamo - Full Moon Photo:
   Type: Sometimes
-  Text: snapping a colorful picture of the full moon
+  Text: showing a picture of the moon to a romantic
 Windfall Island - Minenco - Miss Windfall Photo:
   Type: Sometimes
-  Text: showing Minenco a photo of herself
+  Text: showing a lady a photo of herself
 Windfall Island - Linda and Anton:
   Type: Sometimes
   Text: uniting a young couple with the power of photography
@@ -148,19 +148,19 @@ Ganon's Tower - Maze Chest:
 
 Mailbox - Letter from Hoskit's Girlfriend:
   Type: Sometimes
-  Text: the writings of a grateful girlfriend
+  Text: the writing of a grateful girlfriend
 Mailbox - Letter from Baito:
   Type: Sometimes
-  Text: the writings of a bewildered letter sorter
+  Text: the writing of a bewildered letter sorter
 Mailbox - Letter from Orca:
   Type: Sometimes
-  Text: the writings of your hometown swordsman
+  Text: the writing of your hometown swordsman
 Mailbox - Letter from Aryll:
   Type: Sometimes
-  Text: the writings of your beloved sister
+  Text: the writing of your beloved sister
 Mailbox - Letter from Tingle:
   Type: Sometimes
-  Text: the writings of a rupee-hungry fairy
+  Text: the writing of a rupee-hungry fairy
 
 The Great Sea - Cyclos:
   Type: Sometimes
@@ -235,7 +235,7 @@ Tingle Island - Ankle - Reward for All Tingle Statues:
   Text: collecting five glistening fairy figurines
 Tingle Island - Big Octo:
   Type: Sometimes
-  Text: defeating the sea monstrosity at Tingle's Island
+  Text: defeating the sea monstrosity near the island of greed
 
 Bomb Island - Cave:
   Type: Sometimes

--- a/data/location_hints.txt
+++ b/data/location_hints.txt
@@ -258,7 +258,7 @@ Horseshoe Island - Cave:
 
 Flight Control Platform - Bird-Man Contest - First Prize:
   Type: Sometimes
-  Text: gliding to the Flight Control finish line
+  Text: gliding to the finish line of a contest
 Flight Control Platform - Submarine:
   Type: Sometimes
   Text: defeating Wizzrobes in a dimly-lit submarine

--- a/data/location_hints.txt
+++ b/data/location_hints.txt
@@ -96,13 +96,13 @@ Forbidden Woods - Big Key Chest:
 
 Tower of the Gods - Hop Across Floating Boxes:
   Type: Sometimes
-  Text: hopping across boxes in a godly tower
+  Text: hopping across boxes in a tower created to test the hero
 Tower of the Gods - First Chest Guarded by Armos Knights:
   Type: Sometimes
-  Text: defeating two bomb-hungry foes in a godly tower
+  Text: defeating two bomb-hungry foes in a tower created to test the hero
 Tower of the Gods - Darknut Mini-Boss Room:
   Type: Sometimes
-  Text: defeating a sworded foe in its arena in a godly tower
+  Text: defeating a sworded foe in its arena in a tower created to test the hero
 
 Forsaken Fortress - Phantom Ganon:
   Type: Sometimes

--- a/data/location_hints.txt
+++ b/data/location_hints.txt
@@ -106,7 +106,7 @@ Tower of the Gods - Darknut Mini-Boss Room:
 
 Forsaken Fortress - Phantom Ganon:
   Type: Sometimes
-  Text: playing tennis with an apparition in an arena at a forsaken fortress
+  Text: playing tennis with an apparition in the rubble of the evil's lair
 
 Fire Mountain - Cave - Chest:
   Type: Sometimes

--- a/data/location_hints.txt
+++ b/data/location_hints.txt
@@ -1,303 +1,303 @@
 Outset Island - Orca - Give 10 Knight's Crests:
-  Type: Sometimes
+  Type: Standard
   Text: giving a fellow swordsman crests of honor
 Outset Island - Great Fairy:
-  Type: Sometimes
+  Type: Standard
   Text: visiting the fairy atop the place of all beginnings
 Outset Island - Jabun's Cave:
-  Type: Sometimes
+  Type: Standard
   Text: entering the cave at the back of the place of all beginnings
 Outset Island - Dig up Black Soil:
-  Type: Sometimes
+  Type: Standard
   Text: teaching a pig to dig for treasure
 
 Windfall Island - Chu Jelly Juice Shop - Give 15 Green Chu Jelly:
-  Type: Sometimes
+  Type: Standard
   Text: giving a potion master green jelly
 Windfall Island - Chu Jelly Juice Shop - Give 15 Blue Chu Jelly:
-  Type: Always
+  Type: Remote
   Text: giving a potion master blue jelly
 Windfall Island - Mrs. Marie - Give 40 Joy Pendants:
-  Type: Sometimes
+  Type: Standard
   Text: giving a schoolteacher forty pendants
 Windfall Island - Lenzo's House - Become Lenzo's Assistant:
-  Type: Sometimes
+  Type: Standard
   Text: undertaking a photography apprenticeship
 Windfall Island - Lenzo's House - Bring Forest Firefly:
-  Type: Sometimes
+  Type: Standard
   Text: catching a firefly in a bottle
 Windfall Island - Maggie's Father - Give 20 Skull Necklaces:
-  Type: Sometimes
+  Type: Standard
   Text: giving a wealthy man twenty necklaces
 Windfall Island - Zunari - Stock Exotic Flower in Zunari's Shop:
-  Type: Sometimes
+  Type: Standard
   Text: stocking a shop with three flowers
 Windfall Island - Sam - Decorate the Town:
-  Type: Sometimes
+  Type: Standard
   Text: volunteering to decorate a very populated place
 Windfall Island - Mila - Follow the Thief:
-  Type: Sometimes
+  Type: Standard
   Text: preventing a burglary
 Windfall Island - Battlesquid - Under 20 Shots Prize:
-  Type: Always
+  Type: Remote
   Text: setting a new record in squid-shooting
 Windfall Island - Pompie and Vera - Secret Meeting Photo:
-  Type: Sometimes
+  Type: Standard
   Text: showing a photo to two gossiping ladies
 Windfall Island - Kamo - Full Moon Photo:
-  Type: Sometimes
+  Type: Standard
   Text: showing a picture of the moon to a romantic
 Windfall Island - Minenco - Miss Windfall Photo:
-  Type: Sometimes
+  Type: Standard
   Text: showing a lady a photo of herself
 Windfall Island - Linda and Anton:
-  Type: Sometimes
+  Type: Standard
   Text: uniting a young couple with the power of photography
 
 Dragon Roost Island - Rito Aerie - Give Hoskit 20 Golden Feathers:
-  Type: Sometimes
+  Type: Standard
   Text: gathering feathers for a charitable lover
 Dragon Roost Island - Fly Across Platforms Around Island:
-  Type: Sometimes
+  Type: Standard
   Text: gliding around the home of bird people
 Dragon Roost Island - Rito Aerie - Baito:
-  Type: Sometimes
+  Type: Standard
   Text: mastering the art of letter throwing
 Dragon Roost Island - Secret Cave:
-  Type: Sometimes
+  Type: Standard
   Text: besting the cavern at the home of bird people
 
 Dragon Roost Cavern - Mini-Boss:
-  Type: Sometimes
+  Type: Standard
   Text: freeing the chest in an arena at the summit of a large volcanic den
 Dragon Roost Cavern - Under Rope Bridge:
-  Type: Sometimes
+  Type: Standard
   Text: defeating two Bokoblins near a fragile bridge in a large volcanic den
 Dragon Roost Cavern - Big Key Chest:
-  Type: Sometimes
+  Type: Standard
   Text: placing a Magtail on a switch in a large volcanic den
 
 Forest Haven - On Tree Branch:
-  Type: Sometimes
+  Type: Standard
   Text: receiving a gift from the Great Deku Tree
 Forest Haven - Small Island Chest:
-  Type: Sometimes
+  Type: Standard
   Text: gliding to a remote island near a safe haven
 
 Forbidden Woods - Mothula Mini-Boss Room:
-  Type: Sometimes
+  Type: Standard
   Text: exterminating a flying bug in its arena in a dungeon with overgrown vegetation
 Forbidden Woods - Chest in Locked Tree Trunk:
-  Type: Sometimes
+  Type: Standard
   Text: dropping a bomb flower into a tree trunk in a dungeon with overgrown vegetation
 Forbidden Woods - Big Key Chest:
-  Type: Sometimes
+  Type: Standard
   Text: hitting five switches at once in a dungeon with overgrown vegetation
 
 Tower of the Gods - Hop Across Floating Boxes:
-  Type: Sometimes
+  Type: Standard
   Text: hopping across boxes in a tower created to test the hero
 Tower of the Gods - First Chest Guarded by Armos Knights:
-  Type: Sometimes
+  Type: Standard
   Text: defeating two bomb-hungry foes in a tower created to test the hero
 Tower of the Gods - Darknut Mini-Boss Room:
-  Type: Sometimes
+  Type: Standard
   Text: defeating a sworded foe in its arena in a tower created to test the hero
 
 Forsaken Fortress - Phantom Ganon:
-  Type: Sometimes
+  Type: Standard
   Text: playing tennis with an apparition in the rubble of the evil's lair
 
 Fire Mountain - Cave - Chest:
-  Type: Sometimes
+  Type: Standard
   Text: jumping across dried magma to Magtails
 
 Ice Ring Isle - Inner Cave - Chest:
-  Type: Sometimes
+  Type: Standard
   Text: awakening foes from an icy slumber
 
 Earth Temple - Stalfos Mini-Boss Room:
-  Type: Sometimes
+  Type: Standard
   Text: defeating three Stalfos in a haunted dungeon's arena
 Earth Temple - Kill All Floormasters in Foggy Room:
-  Type: Sometimes
+  Type: Standard
   Text: defeating an army of Floormasters in a haunted dungeon
 Earth Temple - Stalfos Crypt Room:
-  Type: Sometimes
+  Type: Standard
   Text: defeating three Stalfos in a crypt deep in a haunted dungeon
 Earth Temple - Big Key Chest:
-  Type: Sometimes
+  Type: Standard
   Text: defeating a sworded foe in a haunted dungeon
 
 Wind Temple - Big Key Chest:
-  Type: Sometimes
+  Type: Standard
   Text: defeating three sworded foes in a a trap-filled dungeon
 Wind Temple - Wizzrobe Mini-Boss Room:
-  Type: Sometimes
+  Type: Standard
   Text: defeating the Wizzrobe mini-boss in a a trap-filled dungeon's arena
 Wind Temple - Chest Behind Seven Armos:
-  Type: Sometimes
+  Type: Standard
   Text: defeating seven mechanical foes near the top of a a trap-filled dungeon
 Wind Temple - Kill All Enemies in Tall Basement Room:
-  Type: Sometimes
+  Type: Standard
   Text: defeating every enemy in the lowest room of a a trap-filled dungeon
 
 Ganon's Tower - Maze Chest:
-  Type: Always
+  Type: Remote
   Text: navigating the labyrinth in the stronghold of the evil king
 
 Mailbox - Letter from Hoskit's Girlfriend:
-  Type: Sometimes
+  Type: Standard
   Text: the writing of a grateful girlfriend
 Mailbox - Letter from Baito:
-  Type: Sometimes
+  Type: Standard
   Text: the writing of a bewildered letter sorter
 Mailbox - Letter from Orca:
-  Type: Sometimes
+  Type: Standard
   Text: the writing of your hometown swordsman
 Mailbox - Letter from Aryll:
-  Type: Sometimes
+  Type: Standard
   Text: the writing of your beloved sister
 Mailbox - Letter from Tingle:
-  Type: Sometimes
+  Type: Standard
   Text: the writing of a rupee-hungry fairy
 
 The Great Sea - Cyclos:
-  Type: Sometimes
+  Type: Standard
   Text: using a frog in a cyclone as target practice
 The Great Sea - Goron Trading Reward:
-  Type: Always
+  Type: Remote
   Text: showing a golden statuette to a Goron merchant
 The Great Sea - Withered Trees:
-  Type: Always
+  Type: Remote
   Text: restoring life to the trees of the Koroks
 The Great Sea - Ghost Ship:
-  Type: Sometimes
+  Type: Standard
   Text: plundering the haunted ship
 
 Needle Rock Isle - Chest:
-  Type: Sometimes
+  Type: Standard
   Text: activating a switch upon the needle
 Needle Rock Isle - Cave:
-  Type: Sometimes
+  Type: Standard
   Text: lighting torches in a cave of sunken ships
 Needle Rock Isle - Golden Gunboat:
-  Type: Sometimes
+  Type: Standard
   Text: sinking a warship made of gold
 
 Angular Isles - Cave:
-  Type: Sometimes
+  Type: Standard
   Text: pushing blocks inside an island made of blocks
 
 Boating Course - Cave:
-  Type: Sometimes
+  Type: Standard
   Text: lighting three switches at the mercy of Miniblins
 
 Stone Watcher Island - Cave:
-  Type: Sometimes
+  Type: Standard
   Text: besting the trial at the home of the stone watcher
 Stone Watcher Island - Lookout Platform - Destroy the Cannons:
-  Type: Sometimes
+  Type: Standard
   Text: destroying cannons on the lookout platform at the home of the stone watcher
 
 Islet of Steel - Interior:
-  Type: Sometimes
+  Type: Standard
   Text: infiltrating a fort made of steel
 Islet of Steel - Lookout Platform - Defeat the Enemies:
-  Type: Sometimes
+  Type: Standard
   Text: clearing the platform near a fort made of steel
 
 Overlook Island - Cave:
-  Type: Sometimes
+  Type: Standard
   Text: besting the trial at an island made of brick structures
 
 Bird's Peak Rock - Cave:
-  Type: Sometimes
+  Type: Standard
   Text: playing the song of winds in a place where a fruit is required to progress
 
 Pawprint Isle - Chuchu Cave - Scale the Wall:
-  Type: Sometimes
+  Type: Standard
   Text: climbing up pegs in the cave where Chuchus roam
 Pawprint Isle - Wizzrobe Cave:
-  Type: Sometimes
+  Type: Standard
   Text: defeating Wizzrobes in their cave
 
 Thorned Fairy Island - Great Fairy:
-  Type: Sometimes
+  Type: Standard
   Text: visiting the domain of a thorned fairy
 
 Eastern Fairy Island - Lookout Platform - Defeat the Cannons and Enemies:
-  Type: Sometimes
+  Type: Standard
   Text: defending the platform at the domain of an eastern fairy
 
 Tingle Island - Ankle - Reward for All Tingle Statues:
-  Type: Sometimes
+  Type: Standard
   Text: collecting five glistening fairy figurines
 Tingle Island - Big Octo:
-  Type: Sometimes
+  Type: Standard
   Text: defeating the sea monstrosity near the island of greed
 
 Bomb Island - Cave:
-  Type: Sometimes
+  Type: Standard
   Text: besting the trial at an island shaped like an explosive
 
 Rock Spire Isle - Southeast Gunboat:
-  Type: Sometimes
+  Type: Standard
   Text: sinking the warship near the home of the masked shop seller
 
 Shark Island - Cave:
-  Type: Always
+  Type: Remote
   Text: fending off waves in a crimson cave
 
 Horseshoe Island - Play Golf:
-  Type: Sometimes
+  Type: Standard
   Text: playing three holes under par
 Horseshoe Island - Cave:
-  Type: Sometimes
+  Type: Standard
   Text: clearing out Mothulas in an overgrown cave
 
 Flight Control Platform - Bird-Man Contest - First Prize:
-  Type: Sometimes
+  Type: Standard
   Text: gliding to the finish line of a contest
 Flight Control Platform - Submarine:
-  Type: Sometimes
+  Type: Standard
   Text: defeating Wizzrobes in a dimly-lit submarine
 
 Star Island - Cave:
-  Type: Sometimes
+  Type: Standard
   Text: besting the cavern at an island shaped like a star
 
 Five-Star Isles - Lookout Platform - Destroy the Cannons:
-  Type: Sometimes
+  Type: Standard
   Text: making quick work of cannons at the remains of five isles
 Five-Star Isles - Submarine:
-  Type: Sometimes
+  Type: Standard
   Text: defeating Bokoblins in a dimly-lit submarine
 
 Seven-Star Isles - Big Octo:
-  Type: Sometimes
+  Type: Standard
   Text: defeating the sea monstrosity near the remains of seven isles
 
 Cyclops Reef - Destroy the Cannons and Gunboats:
-  Type: Sometimes
+  Type: Standard
   Text: ravaging the one-eyed reef
 
 Two-Eye Reef - Destroy the Cannons and Gunboats:
-  Type: Sometimes
+  Type: Standard
   Text: ravaging the two-eyed reef
 
 Three-Eye Reef - Destroy the Cannons and Gunboats:
-  Type: Sometimes
+  Type: Standard
   Text: ravaging the three-eyed reef
 
 Four-Eye Reef - Destroy the Cannons and Gunboats:
-  Type: Sometimes
+  Type: Standard
   Text: ravaging the four-eyed reef
 
 Five-Eye Reef - Destroy the Cannons:
-  Type: Sometimes
+  Type: Standard
   Text: ravaging the five-eyed reef
 
 Six-Eye Reef - Destroy the Cannons and Gunboats:
-  Type: Sometimes
+  Type: Standard
   Text: ravaging the six-eyed reef

--- a/data/location_hints.txt
+++ b/data/location_hints.txt
@@ -59,23 +59,23 @@ Dragon Roost Island - Rito Aerie - Give Hoskit 20 Golden Feathers:
   Text: gathering feathers for a charitable lover
 Dragon Roost Island - Fly Across Platforms Around Island:
   Type: Sometimes
-  Text: gliding around the home of the Rito
+  Text: gliding around the home of bird people
 Dragon Roost Island - Rito Aerie - Baito:
   Type: Sometimes
   Text: mastering the art of letter throwing
 Dragon Roost Island - Secret Cave:
   Type: Sometimes
-  Text: besting the cavern at the home of the Rito
+  Text: besting the cavern at the home of bird people
 
 Dragon Roost Cavern - Mini-Boss:
   Type: Sometimes
-  Text: freeing the chest in an arena at the summit of a volcanic cavern
+  Text: freeing the chest in an arena at the summit of a large volcanic den
 Dragon Roost Cavern - Under Rope Bridge:
   Type: Sometimes
-  Text: defeating two Bokoblins near a fragile bridge in a volcanic cavern
+  Text: defeating two Bokoblins near a fragile bridge in a large volcanic den
 Dragon Roost Cavern - Big Key Chest:
   Type: Sometimes
-  Text: placing a Magtail on a switch in a volcanic cavern
+  Text: placing a Magtail on a switch in a large volcanic den
 
 Forest Haven - On Tree Branch:
   Type: Sometimes
@@ -86,13 +86,13 @@ Forest Haven - Small Island Chest:
 
 Forbidden Woods - Mothula Mini-Boss Room:
   Type: Sometimes
-  Text: exterminating a flying bug in its arena in a forbidden dungeon
+  Text: exterminating a flying bug in its arena in a dungeon with overgrown vegetation
 Forbidden Woods - Chest in Locked Tree Trunk:
   Type: Sometimes
-  Text: dropping a bomb flower into a tree trunk in a forbidden dungeon
+  Text: dropping a bomb flower into a tree trunk in a dungeon with overgrown vegetation
 Forbidden Woods - Big Key Chest:
   Type: Sometimes
-  Text: hitting five switches at once in a forbidden dungeon
+  Text: hitting five switches at once in a dungeon with overgrown vegetation
 
 Tower of the Gods - Hop Across Floating Boxes:
   Type: Sometimes
@@ -118,29 +118,29 @@ Ice Ring Isle - Inner Cave - Chest:
 
 Earth Temple - Stalfos Mini-Boss Room:
   Type: Sometimes
-  Text: defeating three Stalfos in an earthen dungeon's arena
+  Text: defeating three Stalfos in a haunted dungeon's arena
 Earth Temple - Kill All Floormasters in Foggy Room:
   Type: Sometimes
-  Text: defeating an army of Floormasters in an earthen dungeon
+  Text: defeating an army of Floormasters in a haunted dungeon
 Earth Temple - Stalfos Crypt Room:
   Type: Sometimes
-  Text: defeating three Stalfos in a crypt deep in an earthen dungeon
+  Text: defeating three Stalfos in a crypt deep in a haunted dungeon
 Earth Temple - Big Key Chest:
   Type: Sometimes
-  Text: defeating a sworded foe in an earthen dungeon
+  Text: defeating a sworded foe in a haunted dungeon
 
 Wind Temple - Big Key Chest:
   Type: Sometimes
-  Text: defeating three sworded foes in a windy dungeon
+  Text: defeating three sworded foes in a a trap-filled dungeon
 Wind Temple - Wizzrobe Mini-Boss Room:
   Type: Sometimes
-  Text: defeating the Wizzrobe mini-boss in a windy dungeon's arena
+  Text: defeating the Wizzrobe mini-boss in a a trap-filled dungeon's arena
 Wind Temple - Chest Behind Seven Armos:
   Type: Sometimes
-  Text: defeating seven mechanical foes near the top of a windy dungeon
+  Text: defeating seven mechanical foes near the top of a a trap-filled dungeon
 Wind Temple - Kill All Enemies in Tall Basement Room:
   Type: Sometimes
-  Text: defeating every enemy in the lowest room of a windy dungeon
+  Text: defeating every enemy in the lowest room of a a trap-filled dungeon
 
 Ganon's Tower - Maze Chest:
   Type: Always

--- a/data/location_hints.txt
+++ b/data/location_hints.txt
@@ -3,10 +3,10 @@ Outset Island - Orca - Give 10 Knight's Crests:
   Text: giving a fellow swordsman crests of honor
 Outset Island - Great Fairy:
   Type: Sometimes
-  Text: visiting the Great Fairy atop Outset
+  Text: visiting the fairy atop the place of all beginnings
 Outset Island - Jabun's Cave:
   Type: Sometimes
-  Text: entering the cave at the back of Outset
+  Text: entering the cave at the back of the place of all beginnings
 Outset Island - Dig up Black Soil:
   Type: Sometimes
   Text: teaching a pig to dig for treasure
@@ -34,7 +34,7 @@ Windfall Island - Zunari - Stock Exotic Flower in Zunari's Shop:
   Text: stocking a shop with three flowers
 Windfall Island - Sam - Decorate the Town:
   Type: Sometimes
-  Text: volunteering to decorate Windfall
+  Text: volunteering to decorate a very populated place
 Windfall Island - Mila - Follow the Thief:
   Type: Sometimes
   Text: preventing a burglary
@@ -144,7 +144,7 @@ Wind Temple - Kill All Enemies in Tall Basement Room:
 
 Ganon's Tower - Maze Chest:
   Type: Always
-  Text: navigating the labyrinth in Ganon's Tower
+  Text: navigating the labyrinth in the stronghold of the evil king
 
 Mailbox - Letter from Hoskit's Girlfriend:
   Type: Sometimes
@@ -209,11 +209,11 @@ Islet of Steel - Lookout Platform - Defeat the Enemies:
 
 Overlook Island - Cave:
   Type: Sometimes
-  Text: besting the trial at Overlook
+  Text: besting the trial at an island made of brick structures
 
 Bird's Peak Rock - Cave:
   Type: Sometimes
-  Text: playing the song of winds in Bird's Peak Rock
+  Text: playing the song of winds in a place where a fruit is required to progress
 
 Pawprint Isle - Chuchu Cave - Scale the Wall:
   Type: Sometimes

--- a/data/zone_name_hints.txt
+++ b/data/zone_name_hints.txt
@@ -48,8 +48,8 @@ Cyclops Reef:
   the one-eyed demon
 Six-Eye Reef:
   the six-eyed demon
-Tower of the Gods:
-  a tower created to test the hero
+Tower of the Gods Sector:
+  where a tower created to test the hero lies
 Eastern Triangle Island:
   the green triangle island
 Thorned Fairy Island:
@@ -100,6 +100,16 @@ Mailbox:
   the mail
 The Great Sea:
   a location on the open seas
+Dragon Roost Cavern:
+  a volcanic cavern
+Forbidden Woods:
+  a forbidden dungeon
+Tower of the Gods:
+  a tower created to test the hero
+Earth Temple:
+  an earthen dungeon
+Wind Temple:
+  a windy dungeon
 Hyrule:
   the submerged castle
 Ganon's Tower:

--- a/data/zone_name_hints.txt
+++ b/data/zone_name_hints.txt
@@ -79,7 +79,7 @@ Southern Fairy Island:
 Ice Ring Isle:
   an island ravaged by ice
 Forest Haven:
-  the home of the Koroks
+  the home of the woodland spirits
 Cliff Plateau Isles:
   the remains of a wooden plateau
 Horseshoe Island:

--- a/data/zone_name_hints.txt
+++ b/data/zone_name_hints.txt
@@ -79,7 +79,7 @@ Southern Fairy Island:
 Ice Ring Isle:
   an island ravaged by ice
 Forest Haven:
-  a place where the vegetation is abundant
+  the home of the Koroks
 Cliff Plateau Isles:
   the remains of a wooden plateau
 Horseshoe Island:
@@ -101,15 +101,15 @@ Mailbox:
 The Great Sea:
   a location on the open seas
 Dragon Roost Cavern:
-  a volcanic cavern
+  a large volcanic den
 Forbidden Woods:
-  a forbidden dungeon
+  a dungeon with overgrown vegetation
 Tower of the Gods:
   a tower created to test the hero
 Earth Temple:
-  an earthen dungeon
+  a haunted dungeon
 Wind Temple:
-  a windy dungeon
+  a trap-filled dungeon
 Hyrule:
   the submerged castle
 Ganon's Tower:

--- a/hints.py
+++ b/hints.py
@@ -674,6 +674,13 @@ class Hints:
     if entrance_zone == "Tower of the Gods Sector":
       entrance_zone = "Tower of the Gods"
     
+    # Apply cryptic text, unless the clearer hints option is selected.
+    if self.clearer_hints:
+      item_name = Hints.get_formatted_item_name(item_name)
+    else:
+      item_name = self.progress_item_hints[Hints.get_hint_item_name(item_name)]
+      entrance_zone = self.zone_name_hints[entrance_zone]
+    
     return Hint(HintType.ITEM, entrance_zone, item_name), location_name
   
   
@@ -754,13 +761,6 @@ class Hints:
     # We don't want this Great Fairy to hint at her own item.
     if location_name == "Two-Eye Reef - Big Octo Great Fairy":
       item_hint, location_name = self.get_item_hint(hintable_locations)
-    
-    # Apply cryptic text, unless the clearer hints option is selected.
-    if self.clearer_hints:
-      item_hint.reward = Hints.get_formatted_item_name(item_hint.reward)
-    else:
-      item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
-      item_hint.place = self.zone_name_hints[item_hint.place]
     
     return item_hint
   
@@ -918,13 +918,6 @@ class Hints:
     hinted_item_locations = []
     while len(hintable_locations) > 0 and len(hinted_item_locations) < self.max_item_hints:
       item_hint, location_name = self.get_item_hint(hintable_locations)
-      
-      # Apply cryptic text, unless the clearer hints option is selected.
-      if self.clearer_hints:
-        item_hint.reward = Hints.get_formatted_item_name(item_hint.reward)
-      else:
-        item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
-        item_hint.place = self.zone_name_hints[item_hint.place]
       
       hinted_item_locations.append(item_hint)
       previously_hinted_locations.append(location_name)

--- a/hints.py
+++ b/hints.py
@@ -38,7 +38,7 @@ class Hint:
     return "Hint(%s, %s, %s)" % (str(self.type), repr(self.place), repr(self.reward))
 
 
-class Hints:
+class HintManager:
   # A dictionary mapping dungeon name to the dungeon boss.
   # The boss name is used as the path goal in the hint text.
   DUNGEON_NAME_TO_BOSS_NAME = {
@@ -694,10 +694,10 @@ class Hints:
     item_hint = Hint(HintType.ITEM, entrance_zone, item_name)
     
     if self.cryptic_hints:
-      item_hint.formatted_reward = self.progress_item_hints[Hints.get_hint_item_name(item_name)]
+      item_hint.formatted_reward = self.progress_item_hints[HintManager.get_hint_item_name(item_name)]
       item_hint.formatted_place = self.zone_name_hints[entrance_zone]
     else:
-      item_hint.formatted_reward = Hints.get_formatted_item_name(item_name)
+      item_hint.formatted_reward = HintManager.get_formatted_item_name(item_name)
     
     return item_hint, location_name
   
@@ -736,7 +736,7 @@ class Hints:
     hintable_locations.remove(location_name)
     
     item_name = self.logic.done_item_locations[location_name]
-    item_name = Hints.get_formatted_item_name(item_name)
+    item_name = HintManager.get_formatted_item_name(item_name)
     
     location_hint = Hint(HintType.LOCATION, location_name, item_name)
     
@@ -781,12 +781,12 @@ class Hints:
       if hint is None:
         continue
       if self.cryptic_hints:
-        hint.formatted_reward = Hints.get_hint_item_name(hint.reward)
+        hint.formatted_reward = HintManager.get_hint_item_name(hint.reward)
         if not hint.formatted_reward in self.progress_item_hints:
           raise Exception("Could not find progress item hint for item: %s" % hint.reward)
         hint.formatted_reward = self.progress_item_hints[hint.formatted_reward]
       else:
-        hint.formatted_reward = Hints.get_formatted_item_name(hint.reward)
+        hint.formatted_reward = HintManager.get_formatted_item_name(hint.reward)
     
     return floor_30_hint, floor_50_hint
   

--- a/hints.py
+++ b/hints.py
@@ -856,6 +856,10 @@ class Hints:
         
         # Remove locations that are hinted in always hints from being hinted path.
         if not self.use_always_hints or (location_name not in self.location_hints or self.location_hints[location_name]["Type"] != "Always"):
+          # Apply cryptic text, unless the clearer hints option is selected.
+          if not self.clearer_hints:
+            path_hint.place = self.zone_name_hints[path_hint.place]
+          
           hinted_path_zones.append(path_hint)
           previously_hinted_locations.append(location_name)
     
@@ -869,6 +873,10 @@ class Hints:
       else:
         # Remove locations that are hinted in always hints from being hinted path.
         if not self.use_always_hints or (location_name not in self.location_hints or self.location_hints[location_name]["Type"] != "Always"):
+          # Apply cryptic text, unless the clearer hints option is selected.
+          if not self.clearer_hints:
+            path_hint.place = self.zone_name_hints[path_hint.place]
+          
           hinted_path_zones.append(path_hint)
           previously_hinted_locations.append(location_name)
     

--- a/hints.py
+++ b/hints.py
@@ -778,9 +778,10 @@ class Hints:
       if self.clearer_hints:
         floor_30_item_name = Hints.get_formatted_item_name(floor_30_item_name)
       else:
+        floor_30_item_name = Hints.get_hint_item_name(floor_30_item_name)
         if not floor_30_item_name in self.progress_item_hints:
           raise Exception("Could not find progress item hint for item: %s" % floor_30_item_name)
-        floor_30_item_name = self.progress_item_hints[Hints.get_hint_item_name(floor_30_item_name)]
+        floor_30_item_name = self.progress_item_hints[floor_30_item_name]
       
       floor_30_hint = Hint(HintType.ITEM, None, floor_30_item_name)
     
@@ -790,9 +791,10 @@ class Hints:
       if self.clearer_hints:
         floor_50_item_name = Hints.get_formatted_item_name(floor_50_item_name)
       else:
+        floor_50_item_name = Hints.get_hint_item_name(floor_50_item_name)
         if not floor_50_item_name in self.progress_item_hints:
           raise Exception("Could not find progress item hint for item: %s" % floor_50_item_name)
-        floor_50_item_name = self.progress_item_hints[Hints.get_hint_item_name(floor_50_item_name)]
+        floor_50_item_name = self.progress_item_hints[floor_50_item_name]
       
       floor_50_hint = Hint(HintType.ITEM, None, floor_50_item_name)
     

--- a/hints.py
+++ b/hints.py
@@ -566,9 +566,10 @@ class HintManager:
         continue
       
       # Catch locations which are hinted at in barren dungeons.
-      zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
-      if zone_name in self.logic.DUNGEON_NAMES.values() and zone_name in barrens:
-        continue
+      if self.logic.is_dungeon_location(location_name):
+        zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
+        if zone_name in barrens:
+          continue
       
       # Catch locations which are hinted at in barren zones.
       entrance_zone = self.get_entrance_zone(location_name)

--- a/hints.py
+++ b/hints.py
@@ -497,6 +497,16 @@ class HintManager:
       if self.logic.is_dungeon_location(location_name):
         zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
         zones_with_useful_locations.add(zone_name)
+      
+      # Include dungeon-related mail with its dungeon, in addition to Mailbox.
+      if location_name == "Mailbox - Letter from Baito":
+        zones_with_useful_locations.add("Earth Temple")
+        zones_with_useful_locations.add(self.get_entrance_zone("Earth Temple - Jalhalla Heart Container"))
+      if location_name == "Mailbox - Letter from Orca":
+        zones_with_useful_locations.add("Forbidden Woods")
+        zones_with_useful_locations.add(self.get_entrance_zone("Forbidden Woods - Kalle Demos Heart Container"))
+      if location_name == "Mailbox - Letter from Aryll" or location_name == "Mailbox - Letter from Tingle":
+        zones_with_useful_locations.add("Forsaken Fortress")
     
     # Now, we do the same with barren locations, identifying which zones have barren locations.
     zones_with_barren_locations = set()
@@ -510,6 +520,16 @@ class HintManager:
       if self.logic.is_dungeon_location(location_name):
         zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
         zones_with_barren_locations.add(zone_name)
+      
+      # Include dungeon-related mail with its dungeon, in addition to Mailbox.
+      if location_name == "Mailbox - Letter from Baito":
+        zones_with_barren_locations.add("Earth Temple")
+        zones_with_barren_locations.add(self.get_entrance_zone("Earth Temple - Jalhalla Heart Container"))
+      if location_name == "Mailbox - Letter from Orca":
+        zones_with_barren_locations.add("Forbidden Woods")
+        zones_with_barren_locations.add(self.get_entrance_zone("Forbidden Woods - Kalle Demos Heart Container"))
+      if location_name == "Mailbox - Letter from Aryll" or location_name == "Mailbox - Letter from Tingle":
+        zones_with_barren_locations.add("Forsaken Fortress")
     
     # Finally, the difference between the zones with barren locations and the zones with useful locations gives us our
     # set of hintable barren zones.

--- a/hints.py
+++ b/hints.py
@@ -203,7 +203,7 @@ class Hints:
     # If the item is not a progress item, there's no way it's required.
     item_name = self.logic.done_item_locations[location_to_check]
     if item_name not in self.logic.all_progress_items:
-      return False
+      return {}
     
     # Reuse a single Logic instance over multiple calls to this function for performance reasons.
     self.path_logic.load_simulated_playthrough_state(self.path_logic_initial_state)

--- a/hints.py
+++ b/hints.py
@@ -753,9 +753,13 @@ class Hints:
     if location_name == "Two-Eye Reef - Big Octo Great Fairy":
       item_hint, location_name = self.get_item_hint(hintable_locations)
     
-    # Always use cryptic text for the octo fairy hint
-    item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
-    item_hint.place = self.zone_name_hints[item_hint.place]
+    # Apply cryptic text, unless the clearer hints option is selected.
+    if self.clearer_hints:
+      item_hint.reward = Hints.get_clearer_item_name(item_hint.reward)
+      item_hint.reward = tweaks.add_article_before_item_name(item_hint.reward)
+    else:
+      item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
+      item_hint.place = self.zone_name_hints[item_hint.place]
     
     return item_hint
   
@@ -767,21 +771,31 @@ class Hints:
     floor_30_is_progress = (floor_30_item_name in self.logic.all_progress_items)
     floor_50_is_progress = (floor_50_item_name in self.logic.all_progress_items)
     
-    floor_30_item_name = Hints.get_hint_item_name(floor_30_item_name)
-    floor_50_item_name = Hints.get_hint_item_name(floor_50_item_name)
-    
-    if floor_30_is_progress and not floor_30_item_name in self.progress_item_hints:
-      raise Exception("Could not find progress item hint for item: %s" % floor_30_item_name)
-    if floor_50_is_progress and not floor_50_item_name in self.progress_item_hints:
-      raise Exception("Could not find progress item hint for item: %s" % floor_50_item_name)
-    
-    # Always use cryptic text for the Savage Labyrinth hints
     floor_30_hint = None
     if floor_30_is_progress:
-      floor_30_hint = Hint(HintType.ITEM, None, self.progress_item_hints[floor_30_item_name])
+      # Apply cryptic text, unless the clearer hints option is selected.
+      if self.clearer_hints:
+        floor_30_item_name = Hints.get_clearer_item_name(floor_30_item_name)
+        floor_30_item_name = tweaks.add_article_before_item_name(floor_30_item_name)
+      else:
+        if not floor_30_item_name in self.progress_item_hints:
+          raise Exception("Could not find progress item hint for item: %s" % floor_30_item_name)
+        floor_30_item_name = self.progress_item_hints[Hints.get_hint_item_name(floor_30_item_name)]
+      
+      floor_30_hint = Hint(HintType.ITEM, None, floor_30_item_name)
+    
     floor_50_hint = None
     if floor_50_is_progress:
-      floor_50_hint = Hint(HintType.ITEM, None, self.progress_item_hints[floor_50_item_name])
+      # Apply cryptic text, unless the clearer hints option is selected.
+      if self.clearer_hints:
+        floor_50_item_name = Hints.get_clearer_item_name(floor_50_item_name)
+        floor_50_item_name = tweaks.add_article_before_item_name(floor_50_item_name)
+      else:
+        if not floor_50_item_name in self.progress_item_hints:
+          raise Exception("Could not find progress item hint for item: %s" % floor_50_item_name)
+        floor_50_item_name = self.progress_item_hints[Hints.get_hint_item_name(floor_50_item_name)]
+      
+      floor_50_hint = Hint(HintType.ITEM, None, floor_50_item_name)
     
     return floor_30_hint, floor_50_hint
   

--- a/hints.py
+++ b/hints.py
@@ -732,9 +732,11 @@ class HintManager:
     hintable_locations.remove(location_name)
     
     item_name = self.logic.done_item_locations[location_name]
-    item_name = HintManager.get_formatted_item_name(item_name)
     
     location_hint = Hint(HintType.LOCATION, location_name, item_name)
+    
+    # Never use cryptic item names for location hints.
+    location_hint.formatted_reward = HintManager.get_formatted_item_name(item_name)
     
     if self.cryptic_hints:
       location_hint.formatted_place = self.location_hints[location_name]["Text"]

--- a/hints.py
+++ b/hints.py
@@ -239,7 +239,7 @@ class Hints:
             self.path_logic.add_owned_item(item_name)
             # Remove small key from owned items if it was from the location we want to check
             if small_key_location_name == location_to_check:
-              self.path_logic.currently_owned_items.remove(self.path_logic.clean_item_name(item_name))
+              self.path_logic.remove_owned_item(item_name)
           
           previously_accessible_locations += newly_accessible_small_key_locations
           continue # Redo this loop iteration with the small key locations no longer being considered 'remaining'.
@@ -257,7 +257,7 @@ class Hints:
         self.path_logic.add_owned_item(item_name)
         # Remove item from owned items if it was from the location we want to check.
         if location_name == location_to_check:
-          self.path_logic.currently_owned_items.remove(self.path_logic.clean_item_name(item_name))
+          self.path_logic.remove_owned_item(item_name)
       for group_name, item_names in self.path_logic.progress_item_groups.items():
         entire_group_is_owned = all(item_name in self.path_logic.currently_owned_items for item_name in item_names)
         if entire_group_is_owned and group_name in self.path_logic.unplaced_progress_items:

--- a/hints.py
+++ b/hints.py
@@ -536,7 +536,7 @@ class HintManager:
     barren_zones = zones_with_barren_locations - zones_with_useful_locations
     
     # Return the list of barren zones sorted to maintain consistent ordering.
-    return list(sorted(barren_zones))
+    return sorted(barren_zones)
   
   def get_barren_hint(self, unhinted_zones, zone_weights):
     if len(unhinted_zones) == 0:

--- a/hints.py
+++ b/hints.py
@@ -145,22 +145,23 @@ class Hints:
     
     return hint_string
   
-  def get_clearer_item_name(self, item_name):
+  @staticmethod
+  def get_clearer_item_name(item_name):
     if item_name.endswith("Small Key"):
       short_dungeon_name = item_name.split(" Small Key")[0]
-      dungeon_name = self.logic.DUNGEON_NAMES[short_dungeon_name]
+      dungeon_name = Logic.DUNGEON_NAMES[short_dungeon_name]
       return "%s small key" % dungeon_name
     if item_name.endswith("Big Key"):
       short_dungeon_name = item_name.split(" Big Key")[0]
-      dungeon_name = self.logic.DUNGEON_NAMES[short_dungeon_name]
+      dungeon_name = Logic.DUNGEON_NAMES[short_dungeon_name]
       return "%s Big Key" % dungeon_name
     if item_name.endswith("Dungeon Map"):
       short_dungeon_name = item_name.split(" Dungeon Map")[0]
-      dungeon_name = self.logic.DUNGEON_NAMES[short_dungeon_name]
+      dungeon_name = Logic.DUNGEON_NAMES[short_dungeon_name]
       return "%s Dungeon Map" % dungeon_name
     if item_name.endswith("Compass"):
       short_dungeon_name = item_name.split(" Compass")[0]
-      dungeon_name = self.logic.DUNGEON_NAMES[short_dungeon_name]
+      dungeon_name = Logic.DUNGEON_NAMES[short_dungeon_name]
       return "%s Compass" % dungeon_name
     return item_name
   
@@ -717,7 +718,7 @@ class Hints:
     
     # Apply cryptic text to the location name, unless the clearer hints option is selected.
     item_name = self.logic.done_item_locations[location_name]
-    item_name = self.get_clearer_item_name(item_name)
+    item_name = Hints.get_clearer_item_name(item_name)
     item_name = tweaks.add_article_before_item_name(item_name)
     if not self.clearer_hints:
       location_name = self.location_hints[location_name]["Text"]
@@ -881,7 +882,7 @@ class Hints:
       
       # Apply cryptic text, unless the clearer hints option is selected.
       if self.clearer_hints:
-        item_hint.reward = self.get_clearer_item_name(item_hint.reward)
+        item_hint.reward = Hints.get_clearer_item_name(item_hint.reward)
         item_hint.reward = tweaks.add_article_before_item_name(item_hint.reward)
       else:
         item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]

--- a/hints.py
+++ b/hints.py
@@ -415,14 +415,14 @@ class HintManager:
         valid_path_hint = True
     
     # Record hinted zone, item, and path goal.
-    # If it's a dungeon, use the dungeon name. If it's a cave, use the entrance zone name.
-    if zone_name in self.logic.DUNGEON_NAMES.values():
-      if zone_name == "Tower of the Gods" and specific_location_name == "Sunken Treasure":
-        # Special case: if location is Tower of the Gods - Sunken Treasure, use "Tower of the Gods Sector" as the hint.
-        hint_zone = "Tower of the Gods Sector"
-      else:
-        hint_zone = zone_name
+    if hinted_location == "Tower of the Gods - Sunken Treasure":
+      # Special case: if location is Tower of the Gods - Sunken Treasure, use "Tower of the Gods Sector" as the hint.
+      hint_zone = "Tower of the Gods Sector"
+    elif self.logic.is_dungeon_location(hinted_location):
+      # If it's a dungeon, use the dungeon name.
+      hint_zone = zone_name
     else:
+      # Otherwise, use the entrance zone name.
       hint_zone = entrance_zone
     
     path_hint = Hint(HintType.PATH, self.cryptic_hints, hint_zone, self.DUNGEON_NAME_TO_BOSS_NAME[path_name])
@@ -494,10 +494,9 @@ class HintManager:
       
       zones_with_useful_locations.add(self.get_entrance_zone(location_name))
       # For dungeon locations, both the dungeon and its entrance should be considered useful.
-      zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
-      if zone_name in self.logic.DUNGEON_NAMES.values():
-        if location_name != "Tower of the Gods - Sunken Treasure":
-          zones_with_useful_locations.add(zone_name)
+      if self.logic.is_dungeon_location(location_name):
+        zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
+        zones_with_useful_locations.add(zone_name)
     
     # Now, we do the same with barren locations, identifying which zones have barren locations.
     zones_with_barren_locations = set()
@@ -508,10 +507,9 @@ class HintManager:
       
       zones_with_barren_locations.add(self.get_entrance_zone(location_name))
       # For dungeon locations, both the dungeon and its entrance should be considered barren.
-      zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
-      if zone_name in self.logic.DUNGEON_NAMES.values():
-        if location_name != "Tower of the Gods - Sunken Treasure":
-          zones_with_barren_locations.add(zone_name)
+      if self.logic.is_dungeon_location(location_name):
+        zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
+        zones_with_barren_locations.add(zone_name)
     
     # Finally, the difference between the zones with barren locations and the zones with useful locations gives us our
     # set of hintable barren zones.

--- a/hints.py
+++ b/hints.py
@@ -115,25 +115,39 @@ class Hints:
   
   @staticmethod
   def get_formatted_hint_text(hint, prefix="They say that ", suffix=".", delay=30):
+    place = hint.place
+    if place == "Mailbox":
+      place = "the mail"
+    elif place == "The Great Sea":
+      place = "a location on the open seas"
+    elif place == "Tower of the Gods Sector":
+      place = "the Tower of the Gods sector"
+    
     if hint.type == HintType.PATH:
+      place_preposition = "at"
+      if place in ["the mail", "the Tower of the Gods sector"]:
+        place_preposition = "in"
       hint_string = (
-        "%san item found at \\{1A 06 FF 00 00 05}%s\\{1A 06 FF 00 00 00} is on the path to \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
-        % (prefix, hint.place, hint.reward, suffix)
+        "%san item found %s \\{1A 06 FF 00 00 05}%s\\{1A 06 FF 00 00 00} is on the path to \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
+        % (prefix, place_preposition, place, hint.reward, suffix)
       )
     elif hint.type == HintType.BARREN:
+      verb = "visiting"
+      if place == "the mail":
+        verb = "checking"
       hint_string = (
-        "%svisiting \\{1A 06 FF 00 00 03}%s\\{1A 06 FF 00 00 00} is a foolish choice%s"
-        % (prefix, hint.place, suffix)
+        "%s%s \\{1A 06 FF 00 00 03}%s\\{1A 06 FF 00 00 00} is a foolish choice%s"
+        % (prefix, verb, place, suffix)
       )
     elif hint.type == HintType.LOCATION:
       hint_string = (
         "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00} rewards \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
-        % (prefix, hint.place, hint.reward, suffix)
+        % (prefix, place, hint.reward, suffix)
       )
     elif hint.type == HintType.ITEM:
       hint_string = (
         "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00} is located in \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
-        % (prefix, hint.reward, hint.place, suffix)
+        % (prefix, hint.reward, place, suffix)
       )
     else:
       hint_string = ""

--- a/hints.py
+++ b/hints.py
@@ -160,23 +160,25 @@ class Hints:
     return hint_string
   
   @staticmethod
-  def get_clearer_item_name(item_name):
+  def get_formatted_item_name(item_name):
     if item_name.endswith("Small Key"):
       short_dungeon_name = item_name.split(" Small Key")[0]
       dungeon_name = Logic.DUNGEON_NAMES[short_dungeon_name]
-      return "%s small key" % dungeon_name
-    if item_name.endswith("Big Key"):
+      item_name = "%s small key" % dungeon_name
+    elif item_name.endswith("Big Key"):
       short_dungeon_name = item_name.split(" Big Key")[0]
       dungeon_name = Logic.DUNGEON_NAMES[short_dungeon_name]
-      return "%s Big Key" % dungeon_name
-    if item_name.endswith("Dungeon Map"):
+      item_name = "%s Big Key" % dungeon_name
+    elif item_name.endswith("Dungeon Map"):
       short_dungeon_name = item_name.split(" Dungeon Map")[0]
       dungeon_name = Logic.DUNGEON_NAMES[short_dungeon_name]
-      return "%s Dungeon Map" % dungeon_name
-    if item_name.endswith("Compass"):
+      item_name = "%s Dungeon Map" % dungeon_name
+    elif item_name.endswith("Compass"):
       short_dungeon_name = item_name.split(" Compass")[0]
       dungeon_name = Logic.DUNGEON_NAMES[short_dungeon_name]
-      return "%s Compass" % dungeon_name
+      item_name = "%s Compass" % dungeon_name
+    
+    item_name = tweaks.add_article_before_item_name(item_name)
     return item_name
   
   
@@ -730,10 +732,10 @@ class Hints:
     location_name = self.rando.rng.choice(hintable_locations)
     hintable_locations.remove(location_name)
     
-    # Apply cryptic text to the location name, unless the clearer hints option is selected.
     item_name = self.logic.done_item_locations[location_name]
-    item_name = Hints.get_clearer_item_name(item_name)
-    item_name = tweaks.add_article_before_item_name(item_name)
+    item_name = Hints.get_formatted_item_name(item_name)
+    
+    # Apply cryptic text to the location name, unless the clearer hints option is selected.
     if not self.clearer_hints:
       location_name = self.location_hints[location_name]["Text"]
     
@@ -755,8 +757,7 @@ class Hints:
     
     # Apply cryptic text, unless the clearer hints option is selected.
     if self.clearer_hints:
-      item_hint.reward = Hints.get_clearer_item_name(item_hint.reward)
-      item_hint.reward = tweaks.add_article_before_item_name(item_hint.reward)
+      item_hint.reward = Hints.get_formatted_item_name(item_hint.reward)
     else:
       item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
       item_hint.place = self.zone_name_hints[item_hint.place]
@@ -775,8 +776,7 @@ class Hints:
     if floor_30_is_progress:
       # Apply cryptic text, unless the clearer hints option is selected.
       if self.clearer_hints:
-        floor_30_item_name = Hints.get_clearer_item_name(floor_30_item_name)
-        floor_30_item_name = tweaks.add_article_before_item_name(floor_30_item_name)
+        floor_30_item_name = Hints.get_formatted_item_name(floor_30_item_name)
       else:
         if not floor_30_item_name in self.progress_item_hints:
           raise Exception("Could not find progress item hint for item: %s" % floor_30_item_name)
@@ -788,8 +788,7 @@ class Hints:
     if floor_50_is_progress:
       # Apply cryptic text, unless the clearer hints option is selected.
       if self.clearer_hints:
-        floor_50_item_name = Hints.get_clearer_item_name(floor_50_item_name)
-        floor_50_item_name = tweaks.add_article_before_item_name(floor_50_item_name)
+        floor_50_item_name = Hints.get_formatted_item_name(floor_50_item_name)
       else:
         if not floor_50_item_name in self.progress_item_hints:
           raise Exception("Could not find progress item hint for item: %s" % floor_50_item_name)
@@ -922,8 +921,7 @@ class Hints:
       
       # Apply cryptic text, unless the clearer hints option is selected.
       if self.clearer_hints:
-        item_hint.reward = Hints.get_clearer_item_name(item_hint.reward)
-        item_hint.reward = tweaks.add_article_before_item_name(item_hint.reward)
+        item_hint.reward = Hints.get_formatted_item_name(item_hint.reward)
       else:
         item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
         item_hint.place = self.zone_name_hints[item_hint.place]

--- a/hints.py
+++ b/hints.py
@@ -20,11 +20,6 @@ class HintType(Enum):
   ITEM = 2
   LOCATION = 3
   
-  def __lt__(self, other):
-    if isinstance(other, self.__class__):
-      return self.value < other.value
-    return NotImplemented
-
 
 class Hint:
   def __init__(self, type: HintType, info1, info2=None):
@@ -35,44 +30,8 @@ class Hint:
   def __str__(self):
     return "<HINT: %s, (%s, %s)>" % (str(self.type), self.info1, self.info2)
   
-  def __hash__(self):
-    return hash(str(self))
-  
-  def __lt__(self, other):
-    if isinstance(other, self.__class__):
-      return self.type < other.type
-    return NotImplemented
-  
-  def __eq__(self, other):
-    if isinstance(other, self.__class__):
-      return (
-        (self.type == other.type)
-        and (self.info1 == other.info1)
-        and (self.info2 == other.info2)
-      )
-    else:
-      return False
-
 
 class Hints:
-  # For hinting purposes, these item names can refer to multiple items at multiple locations.
-  PROGRESSIVE_ITEMS = [
-    "Progressive Bow",
-    "Progressive Quiver",
-    "Progressive Bomb Bag",
-    "Progressive Wallet",
-    "Progressive Picto Box",
-    "Progressive Sword",
-    "Progressive Shield",
-    "Progressive Magic Meter",
-    "Empty Bottle",
-
-    "DRC Small Key",
-    "TotG Small Key",
-    "ET Small Key",
-    "WT Small Key",
-  ]
-  
   # A dictionary mapping dungeon name to the dungeon boss.
   # The boss name is used as the path goal in the hint text.
   DUNGEON_NAME_TO_BOSS_NAME = {
@@ -870,7 +829,7 @@ class Hints:
     unhinted_barren_zones = self.get_barren_zones(progress_locations)
     hinted_barren_zones = []
     while len(unhinted_barren_zones) > 0 and len(hinted_barren_zones) < self.max_barren_hints:
-      # Weigh each barren zone by the square root of the number of locations there.
+      # Weight each barren zone by the square root of the number of locations there.
       zone_weights = [sqrt(location_counter[zone]) for zone in unhinted_barren_zones]
       
       barren_hint = self.get_barren_hint(unhinted_barren_zones, zone_weights)

--- a/hints.py
+++ b/hints.py
@@ -754,13 +754,13 @@ class Hints:
     # Note that this hint is completely independant of all other hints.
     progress_locations, non_progress_locations = self.logic.get_progress_and_non_progress_locations()
     hintable_locations = self.get_legal_item_hints(progress_locations, [], [])
+    if "Two-Eye Reef - Big Octo Great Fairy" in hintable_locations:
+      # We don't want this Great Fairy to hint at her own item.
+      hintable_locations.remove("Two-Eye Reef - Big Octo Great Fairy")
     if len(hintable_locations) == 0:
       raise Exception("No valid items to give hints for")
     
     item_hint, location_name = self.get_item_hint(hintable_locations)
-    # We don't want this Great Fairy to hint at her own item.
-    if location_name == "Two-Eye Reef - Big Octo Great Fairy":
-      item_hint, location_name = self.get_item_hint(hintable_locations)
     
     return item_hint
   

--- a/hints.py
+++ b/hints.py
@@ -83,13 +83,9 @@ class HintManager:
     self.cryptic_hints = self.options.get("cryptic_hints")
     self.prioritize_remote_hints = self.options.get("prioritize_remote_hints")
     
-    # Import dictionaries used to build hints from files.
-    with open(os.path.join(DATA_PATH, "progress_item_hints.txt"), "r") as f:
-      self.progress_item_hints = yaml.safe_load(f)
-    with open(os.path.join(DATA_PATH, "zone_name_hints.txt"), "r") as f:
-      self.zone_name_hints = yaml.safe_load(f)
-    with open(os.path.join(DATA_PATH, "location_hints.txt"), "r") as f:
-      self.location_hints = yaml.safe_load(f)
+    self.progress_item_hints = rando.progress_item_hints
+    self.zone_name_hints = rando.zone_name_hints
+    self.location_hints = rando.location_hints
     
     # Validate location names in location hints file.
     for location_name in self.location_hints:

--- a/hints.py
+++ b/hints.py
@@ -145,9 +145,12 @@ class Hints:
         % (prefix, place, hint.reward, suffix)
       )
     elif hint.type == HintType.ITEM:
+      copula = "is"
+      if hint.reward in ["the Power Bracelets", "the Iron Boots", "Bombs"]:
+        copula = "are"
       hint_string = (
-        "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00} is located in \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
-        % (prefix, hint.reward, place, suffix)
+        "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00} %s located in \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
+        % (prefix, hint.reward, copula, place, suffix)
       )
     else:
       hint_string = ""

--- a/hints.py
+++ b/hints.py
@@ -612,28 +612,37 @@ class Hints:
   
   
   def filter_legal_item_hint(self, location_name, progress_locations, previously_hinted_locations):
-    return (
-      # Don't hint at non-progress items.
-      self.logic.done_item_locations[location_name] in self.logic.all_progress_items and
-      
-      # Don't hint at item in non-progress locations.
-      location_name in progress_locations and
-      
-      # Don't hint at dungeon maps and compasses, and don't hint at dungeon keys when key-lunacy is not enabled.
-      (self.options.get("keylunacy") or not self.logic.is_dungeon_item(self.logic.done_item_locations[location_name])) and
-      
-      # You already know which boss locations have a required item and which don't in race mode by looking at the sea chart.
-      location_name not in self.rando.race_mode_required_locations and
-      
-      # Remove locations that are included in remote hints.
-      not (location_name in self.location_hints and self.location_hints[location_name]["Type"] == "Remote") and
-      
-      # Remove locations in race-mode banned dungeons.
-      location_name not in self.rando.race_mode_banned_locations and
-      
-      # Remove locations for items that were previously hinted.
-      location_name not in previously_hinted_locations
-    )
+    item_name = self.logic.done_item_locations[location_name]
+    
+    # Don't hint at non-progress items.
+    if item_name not in self.logic.all_progress_items:
+      return False
+    
+    # Don't hint at item in non-progress locations.
+    if location_name not in progress_locations:
+      return False
+    
+    # Don't hint at dungeon keys when key-lunacy is not enabled.
+    if self.logic.is_dungeon_item(item_name) and not self.options.get("keylunacy"):
+      return False
+    
+    # You already know which boss locations have a required item and which don't in race mode by looking at the sea chart.
+    if location_name in self.rando.race_mode_required_locations:
+      return False
+    
+    # Remove locations that are included in remote hints.
+    if location_name in self.location_hints and self.location_hints[location_name]["Type"] == "Remote":
+      return False
+    
+    # Remove locations in race-mode banned dungeons.
+    if location_name in self.rando.race_mode_banned_locations:
+      return False
+    
+    # Remove locations for items that were previously hinted.
+    if location_name in previously_hinted_locations:
+      return False
+    
+    return True
   
   def get_legal_item_hints(self, progress_locations, hinted_barren_zones, previously_hinted_locations):
     # Helper function to build a list of locations which may be hinted as item hints in this seed.

--- a/hints.py
+++ b/hints.py
@@ -779,10 +779,6 @@ class HintManager:
         if item_tuple in required_locations_for_paths["Ganon's Tower"]:
           required_locations_for_paths["Ganon's Tower"].remove(item_tuple)
     
-    hinted_path_zones = []
-    previously_hinted_locations = []
-    cached_path_items = []
-    
     # Generate a path hint for each race-mode dungeon.
     hinted_path_zones = []
     for dungeon_name in dungeon_paths:
@@ -801,7 +797,6 @@ class HintManager:
         # Remove locations that have already been hinted.
         if location_name not in previously_hinted_locations:
           hinted_path_zones.append(path_hint)
-          cached_path_items.append(self.logic.done_item_locations[location_name])
           previously_hinted_locations.append(location_name)
     
     while len(required_locations_for_paths) > 0 and len(hinted_path_zones) < self.max_path_hints:
@@ -815,7 +810,6 @@ class HintManager:
         # Remove locations that have already been hinted.
         if location_name not in previously_hinted_locations:
           hinted_path_zones.append(path_hint)
-          cached_path_items.append(self.logic.done_item_locations[location_name])
           previously_hinted_locations.append(location_name)
     
     # Generate barren hints.
@@ -858,4 +852,4 @@ class HintManager:
       hinted_standard_locations.append(location_hint)
       previously_hinted_locations.append(location_name)
     
-    return hinted_path_zones + hinted_barren_zones + hinted_item_locations + hinted_remote_locations + hinted_standard_locations, cached_path_items
+    return hinted_path_zones + hinted_barren_zones + hinted_item_locations + hinted_remote_locations + hinted_standard_locations

--- a/hints.py
+++ b/hints.py
@@ -77,7 +77,7 @@ class Hints:
     self.max_item_hints = int(self.options.get("num_item_hints", 0))
     self.total_num_hints = self.max_path_hints + self.max_barren_hints + self.max_location_hints + self.max_item_hints
     
-    self.clearer_hints = self.options.get("clearer_hints")
+    self.cryptic_hints = self.options.get("cryptic_hints")
     self.use_always_hints = self.options.get("use_always_hints")
     
     # Import dictionaries used to build hints from files.
@@ -385,8 +385,7 @@ class Hints:
     else:
       hint_zone = entrance_zone
     
-    # Apply cryptic text, unless the clearer hints option is selected.
-    if not self.clearer_hints:
+    if self.cryptic_hints:
       hint_zone = self.zone_name_hints[hint_zone]
     
     return Hint(HintType.PATH, hint_zone, self.DUNGEON_NAME_TO_BOSS_NAME[path_name]), hinted_location
@@ -606,8 +605,7 @@ class Hints:
     zone_name = self.rando.rng.choices(unhinted_zones, weights=zone_weights)[0]
     unhinted_zones.remove(zone_name)
     
-    # Apply cryptic text, unless the clearer hints option is selected.
-    if not self.clearer_hints:
+    if self.cryptic_hints:
       zone_name = self.zone_name_hints[zone_name]
     
     return Hint(HintType.BARREN, zone_name)
@@ -684,12 +682,11 @@ class Hints:
     if entrance_zone == "Tower of the Gods Sector":
       entrance_zone = "Tower of the Gods"
     
-    # Apply cryptic text, unless the clearer hints option is selected.
-    if self.clearer_hints:
-      item_name = Hints.get_formatted_item_name(item_name)
-    else:
+    if self.cryptic_hints:
       item_name = self.progress_item_hints[Hints.get_hint_item_name(item_name)]
       entrance_zone = self.zone_name_hints[entrance_zone]
+    else:
+      item_name = Hints.get_formatted_item_name(item_name)
     
     return Hint(HintType.ITEM, entrance_zone, item_name), location_name
   
@@ -751,8 +748,7 @@ class Hints:
     item_name = self.logic.done_item_locations[location_name]
     item_name = Hints.get_formatted_item_name(item_name)
     
-    # Apply cryptic text to the location name, unless the clearer hints option is selected.
-    if not self.clearer_hints:
+    if self.cryptic_hints:
       location_name = self.location_hints[location_name]["Text"]
     
     return Hint(HintType.LOCATION, location_name, item_name)
@@ -783,27 +779,25 @@ class Hints:
     
     floor_30_hint = None
     if floor_30_is_progress:
-      # Apply cryptic text, unless the clearer hints option is selected.
-      if self.clearer_hints:
-        floor_30_item_name = Hints.get_formatted_item_name(floor_30_item_name)
-      else:
+      if self.cryptic_hints:
         floor_30_item_name = Hints.get_hint_item_name(floor_30_item_name)
         if not floor_30_item_name in self.progress_item_hints:
           raise Exception("Could not find progress item hint for item: %s" % floor_30_item_name)
         floor_30_item_name = self.progress_item_hints[floor_30_item_name]
+      else:
+        floor_30_item_name = Hints.get_formatted_item_name(floor_30_item_name)
       
       floor_30_hint = Hint(HintType.ITEM, None, floor_30_item_name)
     
     floor_50_hint = None
     if floor_50_is_progress:
-      # Apply cryptic text, unless the clearer hints option is selected.
-      if self.clearer_hints:
-        floor_50_item_name = Hints.get_formatted_item_name(floor_50_item_name)
-      else:
+      if self.cryptic_hints:
         floor_50_item_name = Hints.get_hint_item_name(floor_50_item_name)
         if not floor_50_item_name in self.progress_item_hints:
           raise Exception("Could not find progress item hint for item: %s" % floor_50_item_name)
         floor_50_item_name = self.progress_item_hints[floor_50_item_name]
+      else:
+        floor_50_item_name = Hints.get_formatted_item_name(floor_50_item_name)
       
       floor_50_hint = Hint(HintType.ITEM, None, floor_50_item_name)
     

--- a/hints.py
+++ b/hints.py
@@ -30,6 +30,9 @@ class Hint:
   
   def __str__(self):
     return "<HINT: %s, (%s, %s)>" % (str(self.type), self.place, self.reward)
+  
+  def __repr__(self):
+    return "Hint(%s, %s, %s)" % (str(self.type), repr(self.place), repr(self.reward))
 
 
 class Hints:

--- a/hints.py
+++ b/hints.py
@@ -83,8 +83,8 @@ class Hints:
     # Import dictionaries used to build hints from files.
     with open(os.path.join(DATA_PATH, "progress_item_hints.txt"), "r") as f:
       self.progress_item_hints = yaml.safe_load(f)
-    with open(os.path.join(DATA_PATH, "island_name_hints.txt"), "r") as f:
-      self.island_name_hints = yaml.safe_load(f)
+    with open(os.path.join(DATA_PATH, "zone_name_hints.txt"), "r") as f:
+      self.zone_name_hints = yaml.safe_load(f)
     with open(os.path.join(DATA_PATH, "location_hints.txt"), "r") as f:
       self.location_hints = yaml.safe_load(f)
     
@@ -755,7 +755,7 @@ class Hints:
     
     # Always use cryptic text for the octo fairy hint
     item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
-    item_hint.place = self.island_name_hints[item_hint.place]
+    item_hint.place = self.zone_name_hints[item_hint.place]
     
     return item_hint
   
@@ -883,6 +883,10 @@ class Hints:
       
       barren_hint = self.get_barren_hint(unhinted_barren_zones, zone_weights)
       if barren_hint is not None:
+        # Apply cryptic text, unless the clearer hints option is selected.
+        if not self.clearer_hints:
+          barren_hint.place = self.zone_name_hints[barren_hint.place]
+        
         hinted_barren_zones.append(barren_hint)
     
     # Generate item hints.
@@ -900,7 +904,7 @@ class Hints:
         item_hint.reward = tweaks.add_article_before_item_name(item_hint.reward)
       else:
         item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
-        item_hint.place = self.island_name_hints[item_hint.place]
+        item_hint.place = self.zone_name_hints[item_hint.place]
       
       hinted_item_locations.append(item_hint)
       previously_hinted_locations.append(location_name)

--- a/hints.py
+++ b/hints.py
@@ -646,10 +646,6 @@ class Hints:
     if location_name in self.rando.race_mode_required_locations:
       return False
     
-    # Remove locations that are included in remote hints.
-    if location_name in self.location_hints and self.location_hints[location_name]["Type"] == "Remote":
-      return False
-    
     # Remove locations in race-mode banned dungeons.
     if location_name in self.rando.race_mode_banned_locations:
       return False

--- a/hints.py
+++ b/hints.py
@@ -8,6 +8,7 @@ import yaml
 from logic.item_types import CONSUMABLE_ITEMS, DUNGEON_NONPROGRESS_ITEMS, DUNGEON_PROGRESS_ITEMS
 from logic.logic import Logic
 from wwrando_paths import DATA_PATH
+import tweaks
 
 ITEM_LOCATION_NAME_TO_EXIT_ZONE_NAME_OVERRIDES = {
   "Pawprint Isle - Wizzrobe Cave": "Pawprint Isle Side Isle",
@@ -19,7 +20,7 @@ class HintType(Enum):
   BARREN = 1
   ITEM = 2
   LOCATION = 3
-  
+
 
 class Hint:
   def __init__(self, type: HintType, info1, info2=None):
@@ -29,7 +30,7 @@ class Hint:
   
   def __str__(self):
     return "<HINT: %s, (%s, %s)>" % (str(self.type), self.info1, self.info2)
-  
+
 
 class Hints:
   # A dictionary mapping dungeon name to the dungeon boss.
@@ -685,7 +686,9 @@ class Hints:
     
     # Apply cryptic text to the location name, unless the clearer hints option is selected.
     item_name = self.logic.done_item_locations[location_name]
-    if not self.clearer_hints:
+    if self.clearer_hints:
+      item_name = tweaks.add_article_before_item_name(item_name)
+    else:
       location_name = self.location_hints[location_name]["Text"]
     
     return Hint(HintType.LOCATION, location_name, item_name)
@@ -846,7 +849,9 @@ class Hints:
       item_hint, location_name = self.get_item_hint(hintable_locations)
       
       # Apply cryptic text, unless the clearer hints option is selected.
-      if not self.clearer_hints:
+      if self.clearer_hints:
+        item_hint.info1 = tweaks.add_article_before_item_name(item_hint.info1)
+      else:
         item_hint.info1 = self.progress_item_hints[Hints.get_hint_item_name(item_hint.info1)]
         item_hint.info2 = self.island_name_hints[item_hint.info2]
       

--- a/hints.py
+++ b/hints.py
@@ -23,13 +23,13 @@ class HintType(Enum):
 
 
 class Hint:
-  def __init__(self, type: HintType, info1, info2=None):
+  def __init__(self, type: HintType, place, reward=None):
     self.type = type
-    self.info1 = info1
-    self.info2 = info2
+    self.place = place
+    self.reward = reward
   
   def __str__(self):
-    return "<HINT: %s, (%s, %s)>" % (str(self.type), self.info1, self.info2)
+    return "<HINT: %s, (%s, %s)>" % (str(self.type), self.place, self.reward)
 
 
 class Hints:
@@ -112,22 +112,22 @@ class Hints:
     if hint.type == HintType.PATH:
       hint_string = (
         "%san item found at \\{1A 06 FF 00 00 05}%s\\{1A 06 FF 00 00 00} is on the path to \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
-        % (prefix, hint.info1, hint.info2, suffix)
+        % (prefix, hint.place, hint.reward, suffix)
       )
     elif hint.type == HintType.BARREN:
       hint_string = (
         "%svisiting \\{1A 06 FF 00 00 03}%s\\{1A 06 FF 00 00 00} is a foolish choice%s"
-        % (prefix, hint.info1, suffix)
+        % (prefix, hint.place, suffix)
       )
     elif hint.type == HintType.LOCATION:
       hint_string = (
         "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00} rewards \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
-        % (prefix, hint.info1, hint.info2, suffix)
+        % (prefix, hint.place, hint.reward, suffix)
       )
     elif hint.type == HintType.ITEM:
       hint_string = (
         "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00} is located in \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
-        % (prefix, hint.info1, hint.info2, suffix)
+        % (prefix, hint.reward, hint.place, suffix)
       )
     else:
       hint_string = ""
@@ -587,7 +587,7 @@ class Hints:
     
     # Remove locations in hinted barren areas.
     new_hintable_locations = []
-    barrens = [hint.info1 for hint in hinted_barren_zones]
+    barrens = [hint.place for hint in hinted_barren_zones]
     for location_name in hintable_locations:
       # Catch Mailbox cases.
       if (
@@ -626,7 +626,7 @@ class Hints:
     if entrance_zone == "Tower of the Gods Sector":
       entrance_zone = "Tower of the Gods"
     
-    return Hint(HintType.ITEM, item_name, entrance_zone), location_name
+    return Hint(HintType.ITEM, entrance_zone, item_name), location_name
   
   
   def get_legal_location_hints(self, progress_locations, hinted_barren_zones, previously_hinted_locations):
@@ -652,7 +652,7 @@ class Hints:
     
     # Remove locations in hinted barren areas.
     sometimes_hintable_locations = []
-    barrens = [hint.info1 for hint in hinted_barren_zones]
+    barrens = [hint.place for hint in hinted_barren_zones]
     for location_name in hintable_locations:
       # Catch Mailbox cases.
       if (
@@ -708,8 +708,8 @@ class Hints:
       item_hint, location_name = self.get_item_hint(hintable_locations)
     
     # Always use cryptic text for the octo fairy hint
-    item_hint.info1 = self.progress_item_hints[Hints.get_hint_item_name(item_hint.info1)]
-    item_hint.info2 = self.island_name_hints[item_hint.info2]
+    item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
+    item_hint.place = self.island_name_hints[item_hint.place]
     
     return item_hint
   
@@ -732,10 +732,10 @@ class Hints:
     # Always use cryptic text for the Savage Labyrinth hints
     floor_30_hint = None
     if floor_30_is_progress:
-      floor_30_hint = Hint(HintType.ITEM, self.progress_item_hints[floor_30_item_name])
+      floor_30_hint = Hint(HintType.ITEM, None, self.progress_item_hints[floor_30_item_name])
     floor_50_hint = None
     if floor_50_is_progress:
-      floor_50_hint = Hint(HintType.ITEM, self.progress_item_hints[floor_50_item_name])
+      floor_50_hint = Hint(HintType.ITEM, None, self.progress_item_hints[floor_50_item_name])
     
     return floor_30_hint, floor_50_hint
   
@@ -850,10 +850,10 @@ class Hints:
       
       # Apply cryptic text, unless the clearer hints option is selected.
       if self.clearer_hints:
-        item_hint.info1 = tweaks.add_article_before_item_name(item_hint.info1)
+        item_hint.reward = tweaks.add_article_before_item_name(item_hint.reward)
       else:
-        item_hint.info1 = self.progress_item_hints[Hints.get_hint_item_name(item_hint.info1)]
-        item_hint.info2 = self.island_name_hints[item_hint.info2]
+        item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]
+        item_hint.place = self.island_name_hints[item_hint.place]
       
       hinted_item_locations.append(item_hint)
       previously_hinted_locations.append(location_name)

--- a/hints.py
+++ b/hints.py
@@ -142,6 +142,25 @@ class Hints:
     
     return hint_string
   
+  def get_clearer_item_name(self, item_name):
+    if item_name.endswith("Small Key"):
+      short_dungeon_name = item_name.split(" Small Key")[0]
+      dungeon_name = self.logic.DUNGEON_NAMES[short_dungeon_name]
+      return "%s small key" % dungeon_name
+    if item_name.endswith("Big Key"):
+      short_dungeon_name = item_name.split(" Big Key")[0]
+      dungeon_name = self.logic.DUNGEON_NAMES[short_dungeon_name]
+      return "%s Big Key" % dungeon_name
+    if item_name.endswith("Dungeon Map"):
+      short_dungeon_name = item_name.split(" Dungeon Map")[0]
+      dungeon_name = self.logic.DUNGEON_NAMES[short_dungeon_name]
+      return "%s Dungeon Map" % dungeon_name
+    if item_name.endswith("Compass"):
+      short_dungeon_name = item_name.split(" Compass")[0]
+      dungeon_name = self.logic.DUNGEON_NAMES[short_dungeon_name]
+      return "%s Compass" % dungeon_name
+    return item_name
+  
   
   def get_entrance_zone(self, location_name):
     # Helper function to return the entrance zone name for the location.
@@ -695,9 +714,9 @@ class Hints:
     
     # Apply cryptic text to the location name, unless the clearer hints option is selected.
     item_name = self.logic.done_item_locations[location_name]
-    if self.clearer_hints:
-      item_name = tweaks.add_article_before_item_name(item_name)
-    else:
+    item_name = self.get_clearer_item_name(item_name)
+    item_name = tweaks.add_article_before_item_name(item_name)
+    if not self.clearer_hints:
       location_name = self.location_hints[location_name]["Text"]
     
     return Hint(HintType.LOCATION, location_name, item_name)
@@ -859,6 +878,7 @@ class Hints:
       
       # Apply cryptic text, unless the clearer hints option is selected.
       if self.clearer_hints:
+        item_hint.reward = self.get_clearer_item_name(item_hint.reward)
         item_hint.reward = tweaks.add_article_before_item_name(item_hint.reward)
       else:
         item_hint.reward = self.progress_item_hints[Hints.get_hint_item_name(item_hint.reward)]

--- a/hints.py
+++ b/hints.py
@@ -45,7 +45,7 @@ class Hint:
   @property
   def formatted_reward(self):
     match self.type:
-      case HintType.PATH:
+      case HintType.PATH | HintType.BARREN:
         return self.reward
       case HintType.ITEM:
         if self.is_cryptic:
@@ -759,6 +759,10 @@ class HintManager:
         if item_tuple in required_locations_for_paths["Ganon's Tower"]:
           required_locations_for_paths["Ganon's Tower"].remove(item_tuple)
     
+    hinted_path_zones = []
+    previously_hinted_locations = []
+    cached_path_items = []
+    
     # Generate a path hint for each race-mode dungeon.
     hinted_path_zones = []
     for dungeon_name in dungeon_paths:
@@ -777,6 +781,7 @@ class HintManager:
         # Remove locations that have already been hinted.
         if location_name not in previously_hinted_locations:
           hinted_path_zones.append(path_hint)
+          cached_path_items.append(self.logic.done_item_locations[location_name])
           previously_hinted_locations.append(location_name)
     
     while len(required_locations_for_paths) > 0 and len(hinted_path_zones) < self.max_path_hints:
@@ -790,6 +795,7 @@ class HintManager:
         # Remove locations that have already been hinted.
         if location_name not in previously_hinted_locations:
           hinted_path_zones.append(path_hint)
+          cached_path_items.append(self.logic.done_item_locations[location_name])
           previously_hinted_locations.append(location_name)
     
     # Generate barren hints.
@@ -832,4 +838,4 @@ class HintManager:
       hinted_standard_locations.append(location_hint)
       previously_hinted_locations.append(location_name)
     
-    return hinted_path_zones + hinted_barren_zones + hinted_item_locations + hinted_remote_locations + hinted_standard_locations
+    return hinted_path_zones + hinted_barren_zones + hinted_item_locations + hinted_remote_locations + hinted_standard_locations, cached_path_items

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -46,6 +46,9 @@ class Logic:
     ]),
   ])
   
+  initial_item_locations = None
+  initial_macros = None
+  
   def __init__(self, rando):
     self.rando = rando
     self.requirement_met_cache = {}
@@ -657,6 +660,9 @@ class Logic:
   
   @staticmethod
   def load_and_parse_item_locations():
+    if Logic.initial_item_locations is not None:
+      return Logic.initial_item_locations.copy()
+    
     with open(os.path.join(LOGIC_PATH, "item_locations.txt")) as f:
       item_locations = yaml.load(f, YamlOrderedDictLoader)
     
@@ -671,14 +677,23 @@ class Logic:
       types = [type.strip() for type in types]
       item_locations[location_name]["Types"] = types
     
+    Logic.initial_item_locations = item_locations.copy()
     return item_locations
     
   def load_and_parse_macros(self):
+    if Logic.initial_macros is not None:
+      self.macros = Logic.initial_macros.copy()
+      return self.macros
+    
     with open(os.path.join(LOGIC_PATH, "macros.txt")) as f:
       macro_strings = yaml.safe_load(f)
+    
     self.macros = {}
     for macro_name, req_string in macro_strings.items():
       self.set_macro(macro_name, req_string)
+    
+    Logic.initial_macros = self.macros.copy()
+    return self.macros
   
   def set_macro(self, macro_name, req_string):
     self.macros[macro_name] = Logic.parse_logic_expression(req_string)

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -145,6 +145,8 @@ class Logic:
     for item_name in self.rando.starting_items:
       self.add_owned_item(item_name)
     
+    # Decide what will count as a progress item on these settings.
+    self.requirement_met_cache.clear()
     self.make_useless_progress_items_nonprogress()
     
     # Replace progress items that are part of a group with the group name instead.
@@ -166,6 +168,7 @@ class Logic:
         if group_name in self.unplaced_progress_items:
           self.unplaced_progress_items.remove(group_name)
     
+    self.requirement_met_cache.clear()
     self.cached_enemies_tested_for_reqs_tuple = OrderedDict()
   
   def is_dungeon_or_cave(self, location_name):

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -183,12 +183,12 @@ class Logic:
       "unplaced_fixed_consumable_items",
       "requirement_met_cache",
     ]:
-      vars_backup[attr_name] = getattr(self, attr_name).copy()
+      vars_backup[attr_name] = copy.deepcopy(getattr(self, attr_name))
     return vars_backup
   
   def load_simulated_playthrough_state(self, vars_backup):
     for attr_name, value in vars_backup.items():
-      setattr(self, attr_name, value.copy())
+      setattr(self, attr_name, copy.deepcopy(value))
   
   def is_dungeon_or_cave(self, location_name):
     # Look up the setting that the location name is under
@@ -677,7 +677,7 @@ class Logic:
   @staticmethod
   def load_and_parse_item_locations():
     if Logic.initial_item_locations is not None:
-      return Logic.initial_item_locations.copy()
+      return copy.deepcopy(Logic.initial_item_locations)
     
     with open(os.path.join(LOGIC_PATH, "item_locations.txt")) as f:
       item_locations = yaml.load(f, YamlOrderedDictLoader)
@@ -693,12 +693,12 @@ class Logic:
       types = [type.strip() for type in types]
       item_locations[location_name]["Types"] = types
     
-    Logic.initial_item_locations = item_locations.copy()
+    Logic.initial_item_locations = copy.deepcopy(item_locations)
     return item_locations
     
   def load_and_parse_macros(self):
     if Logic.initial_macros is not None:
-      self.macros = Logic.initial_macros.copy()
+      self.macros = copy.deepcopy(Logic.initial_macros)
       return self.macros
     
     with open(os.path.join(LOGIC_PATH, "macros.txt")) as f:
@@ -708,7 +708,7 @@ class Logic:
     for macro_name, req_string in macro_strings.items():
       self.set_macro(macro_name, req_string)
     
-    Logic.initial_macros = self.macros.copy()
+    Logic.initial_macros = copy.deepcopy(self.macros)
     return self.macros
   
   def set_macro(self, macro_name, req_string):

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -174,6 +174,22 @@ class Logic:
     self.requirement_met_cache.clear()
     self.cached_enemies_tested_for_reqs_tuple = OrderedDict()
   
+  def save_simulated_playthrough_state(self):
+    vars_backup = {}
+    for attr_name in [
+      "currently_owned_items",
+      "unplaced_progress_items",
+      "unplaced_nonprogress_items",
+      "unplaced_fixed_consumable_items",
+      "requirement_met_cache",
+    ]:
+      vars_backup[attr_name] = getattr(self, attr_name).copy()
+    return vars_backup
+  
+  def load_simulated_playthrough_state(self, vars_backup):
+    for attr_name, value in vars_backup.items():
+      setattr(self, attr_name, value.copy())
+  
   def is_dungeon_or_cave(self, location_name):
     # Look up the setting that the location name is under
     is_dungeon = "Dungeon" in self.item_locations[location_name]["Types"]

--- a/randomizer.py
+++ b/randomizer.py
@@ -76,7 +76,7 @@ RNG_CHANGING_OPTIONS = [
   "num_location_hints",
   "num_item_hints",
   "cryptic_hints",
-  "use_always_hints",
+  "prioritize_remote_hints",
   "do_not_generate_spoiler_log",
 ]
 

--- a/randomizer.py
+++ b/randomizer.py
@@ -646,15 +646,15 @@ class Randomizer:
     with open(os.path.join(ASM_PATH, "custom_symbols.txt"), "r") as f:
       self.custom_symbols = yaml.safe_load(f)
     self.main_custom_symbols = self.custom_symbols["sys/main.dol"]
-    
     with open(os.path.join(ASM_PATH, "free_space_start_offsets.txt"), "r") as f:
       self.free_space_start_offsets = yaml.safe_load(f)
     
     with open(os.path.join(DATA_PATH, "progress_item_hints.txt"), "r") as f:
       self.progress_item_hints = yaml.safe_load(f)
-    
     with open(os.path.join(DATA_PATH, "zone_name_hints.txt"), "r") as f:
       self.zone_name_hints = yaml.safe_load(f)
+    with open(os.path.join(DATA_PATH, "location_hints.txt"), "r") as f:
+      self.location_hints = yaml.safe_load(f)
     
     with open(os.path.join(DATA_PATH, "enemy_types.txt"), "r") as f:
       self.enemy_types = yaml.safe_load(f)

--- a/randomizer.py
+++ b/randomizer.py
@@ -653,8 +653,8 @@ class Randomizer:
     with open(os.path.join(DATA_PATH, "progress_item_hints.txt"), "r") as f:
       self.progress_item_hints = yaml.safe_load(f)
     
-    with open(os.path.join(DATA_PATH, "island_name_hints.txt"), "r") as f:
-      self.island_name_hints = yaml.safe_load(f)
+    with open(os.path.join(DATA_PATH, "zone_name_hints.txt"), "r") as f:
+      self.zone_name_hints = yaml.safe_load(f)
     
     with open(os.path.join(DATA_PATH, "enemy_types.txt"), "r") as f:
       self.enemy_types = yaml.safe_load(f)

--- a/randomizer.py
+++ b/randomizer.py
@@ -453,7 +453,7 @@ class Randomizer:
     options_completed += 1
     
     yield("Generating hints...", options_completed)
-    if self.randomize_items and not self.dry_run:
+    if self.randomize_items:
       self.reset_rng()
       tweaks.randomize_and_update_hints(self)
     options_completed += 5

--- a/randomizer.py
+++ b/randomizer.py
@@ -649,13 +649,6 @@ class Randomizer:
     with open(os.path.join(ASM_PATH, "free_space_start_offsets.txt"), "r") as f:
       self.free_space_start_offsets = yaml.safe_load(f)
     
-    with open(os.path.join(DATA_PATH, "progress_item_hints.txt"), "r") as f:
-      self.progress_item_hints = yaml.safe_load(f)
-    with open(os.path.join(DATA_PATH, "zone_name_hints.txt"), "r") as f:
-      self.zone_name_hints = yaml.safe_load(f)
-    with open(os.path.join(DATA_PATH, "location_hints.txt"), "r") as f:
-      self.location_hints = yaml.safe_load(f)
-    
     with open(os.path.join(DATA_PATH, "enemy_types.txt"), "r") as f:
       self.enemy_types = yaml.safe_load(f)
     

--- a/randomizer.py
+++ b/randomizer.py
@@ -75,7 +75,7 @@ RNG_CHANGING_OPTIONS = [
   "num_barren_hints",
   "num_location_hints",
   "num_item_hints",
-  "clearer_hints",
+  "cryptic_hints",
   "use_always_hints",
   "do_not_generate_spoiler_log",
 ]

--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -8,7 +8,7 @@ from fs_helpers import *
 def randomize_items(self):
   print("Randomizing items...")
   
-  if self.options.get("race_mode"):
+  if self.options.get("progression_dungeons") and self.options.get("race_mode"):
     randomize_boss_rewards(self)
   
   if not self.options.get("keylunacy"):

--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -8,7 +8,7 @@ from fs_helpers import *
 def randomize_items(self):
   print("Randomizing items...")
   
-  if self.options.get("progression_dungeons") and self.options.get("race_mode"):
+  if self.options.get("race_mode"):
     randomize_boss_rewards(self)
   
   if not self.options.get("keylunacy"):

--- a/tweaks.py
+++ b/tweaks.py
@@ -915,14 +915,14 @@ def update_savage_labyrinth_hint_tablet(self, floor_30_hint, floor_50_hint):
   )
 
 def randomize_and_update_hints(self):
-  hints_manager = HintManager(self)
+  hint_manager = HintManager(self)
   
   # Give the Big Octo Great Fairy a unique item hint
-  octo_fairy_hint = hints_manager.generate_octo_fairy_hint()
+  octo_fairy_hint = hint_manager.generate_octo_fairy_hint()
   update_big_octo_great_fairy_item_name_hint(self, octo_fairy_hint)
   
   # Update the hint tablet in Savage Labyrinth
-  floor_30_hint, floor_50_hint = hints_manager.generate_savage_labyrinth_hints()
+  floor_30_hint, floor_50_hint = hint_manager.generate_savage_labyrinth_hints()
   update_savage_labyrinth_hint_tablet(self, floor_30_hint, floor_50_hint)
   
   # Identify where the user wishes hints to be located
@@ -933,11 +933,11 @@ def randomize_and_update_hints(self):
       hints_per_placement[option] = []
   
   hint_placement_options = list(hints_per_placement.keys())
-  if hints_manager.total_num_hints == 0 or len(hint_placement_options) == 0:
+  if hint_manager.total_num_hints == 0 or len(hint_placement_options) == 0:
     return
   
   # Generate the hints that will be distributed over the hint placement options
-  hints = hints_manager.generate_hints()
+  hints = hint_manager.generate_hints()
   
   # If there are less hints than placement options, duplicate the hints so that all selected placement options have at
   # least one hint.

--- a/tweaks.py
+++ b/tweaks.py
@@ -933,6 +933,13 @@ def randomize_and_update_hints(self):
   # Generate the hints that will be distributed over the hint placement options
   hints = hints_manager.generate_hints()
   
+  # If there are less hints than placement options, duplicate the hints so that all selected placement options have at
+  # least one hint.
+  duplicated_hints = []
+  while len(hints) + len(duplicated_hints) < len(hint_placement_options):
+    duplicated_hints += self.rng.sample(hints, len(hints))
+  hints += duplicated_hints[:(len(hint_placement_options) - len(hints))]
+  
   # Distribute the hints among the enabled hint placement options
   self.rng.shuffle(hint_placement_options)
   for i, hint in enumerate(hints):

--- a/tweaks.py
+++ b/tweaks.py
@@ -958,6 +958,7 @@ def randomize_and_update_hints(self):
       print("Invalid hint placement option: %s" % hint_placement)
 
 def update_fishmen_hints(self, hints):
+  assert hints
   if self.dry_run:
     return
   
@@ -988,6 +989,7 @@ def update_fishmen_hints(self, hints):
     msg.string = hint
 
 def update_hoho_hints(self, hints):
+  assert hints
   if self.dry_run:
     return
   
@@ -1031,6 +1033,7 @@ def update_hoho_hints(self, hints):
     msg.string = hint
 
 def update_korl_hints(self, hints):
+  assert hints
   if self.dry_run:
     return
   

--- a/tweaks.py
+++ b/tweaks.py
@@ -9,7 +9,7 @@ from random import Random
 import math
 
 from fs_helpers import *
-from hints import Hints, HintType
+from hints import HintManager, HintType
 from asm import patcher
 from wwlib import texture_utils
 from wwlib.rel import REL
@@ -915,7 +915,7 @@ def update_savage_labyrinth_hint_tablet(self, floor_30_hint, floor_50_hint):
   )
 
 def randomize_and_update_hints(self):
-  hints_manager = Hints(self)
+  hints_manager = HintManager(self)
   
   # Give the Big Octo Great Fairy a unique item hint
   octo_fairy_hint = hints_manager.generate_octo_fairy_hint()
@@ -975,7 +975,7 @@ def update_fishmen_hints(self, hints):
     hint = hints[fishman_hint_number % len(hints)]
     
     hint_lines = []
-    hint_lines.append(Hints.get_formatted_hint_text(hint, prefix="I've heard from my sources that ", suffix=".", delay=60))
+    hint_lines.append(HintManager.get_formatted_hint_text(hint, prefix="I've heard from my sources that ", suffix=".", delay=60))
     
     if self.options.get("cryptic_hints") and (hint.type == HintType.ITEM or hint.type == HintType.LOCATION):
       hint_lines.append("Could be worth a try checking that place out. If you know where it is, of course.")
@@ -1022,7 +1022,7 @@ def update_hoho_hints(self, hints):
       hint_prefix = "\\{1A 05 01 01 03}Ho ho! To think that " if i == 0 else "and that "
       hint_suffix = "..." if i == len(hints_for_hoho) - 1 else ","
       
-      hint_lines.append(Hints.get_formatted_hint_text(hint, prefix=hint_prefix, suffix=hint_suffix))
+      hint_lines.append(HintManager.get_formatted_hint_text(hint, prefix=hint_prefix, suffix=hint_suffix))
       
       if self.options.get("instant_text_boxes") and i > 0:
         # If instant text mode is on, we need to reset the text speed to instant after the wait command messed it up.
@@ -1048,7 +1048,7 @@ def update_korl_hints(self, hints):
     # Have no delay with KoRL text since he potentially has a lot of textboxes
     hint_prefix = "They say that " if i == 0 else "and that "
     hint_suffix = "." if i == len(hints) - 1 else ","
-    hint_lines.append(Hints.get_formatted_hint_text(hint, prefix=hint_prefix, suffix=hint_suffix, delay=0))
+    hint_lines.append(HintManager.get_formatted_hint_text(hint, prefix=hint_prefix, suffix=hint_suffix, delay=0))
   
   hint = ""
   for hint_line in hint_lines:

--- a/tweaks.py
+++ b/tweaks.py
@@ -980,7 +980,7 @@ def update_fishmen_hints(self, hints):
     
     hint = ""
     for hint_line in hint_lines:
-      hint_line = word_wrap_string(hint_line)
+      hint_line = word_wrap_string(hint_line, max_line_length=43)
       hint_line = pad_string_to_next_4_lines(hint_line)
       hint += hint_line
     
@@ -1024,7 +1024,7 @@ def update_hoho_hints(self, hints):
     
     hint = ""
     for hint_line in hint_lines:
-      hint_line = word_wrap_string(hint_line)
+      hint_line = word_wrap_string(hint_line, max_line_length=43)
       hint_line = pad_string_to_next_4_lines(hint_line)
       hint += hint_line
     
@@ -1046,7 +1046,7 @@ def update_korl_hints(self, hints):
   
   hint = ""
   for hint_line in hint_lines:
-    hint_line = word_wrap_string(hint_line)
+    hint_line = word_wrap_string(hint_line, max_line_length=43)
     hint_line = pad_string_to_next_4_lines(hint_line)
     hint += hint_line
   

--- a/tweaks.py
+++ b/tweaks.py
@@ -692,11 +692,17 @@ def word_wrap_string(string, max_line_length=34):
       index_in_str += 1
     elif char == " ":
       wordwrapped_str += current_word
-      wordwrapped_str += char
-      length_of_curr_line += current_word_length + len(char)
+      length_of_curr_line += current_word_length
       current_word = ""
       current_word_length = 0
       index_in_str += 1
+      
+      if length_of_curr_line + len(char) >= max_line_length:
+        wordwrapped_str += "\n"
+        length_of_curr_line = 0
+      else:
+        wordwrapped_str += char
+        length_of_curr_line += len(char)
     else:
       current_word += char
       current_word_length += 1

--- a/tweaks.py
+++ b/tweaks.py
@@ -740,12 +740,12 @@ def add_article_before_item_name(item_name):
     article = get_indefinite_article(item_name)
   elif item_name.lower().endswith(" small key"):
     article = get_indefinite_article(item_name)
-  elif item_name in ["Beedle's Chart", "Tingle's Chart", "Maggie's Letter"]:
-    article = None
-  elif item_name.endswith("'s Pearl"):
-    article = None
-  elif item_name in ["Father's Letter", "Moblin's Letter"]:
+  elif item_name in ["Delivery Bag", "Boat's Sail", "Note to Mom"]:
     article = get_indefinite_article(item_name)
+  elif item_name in ["Beedle's Chart", "Bombs", "Tingle's Chart", "Maggie's Letter", "Father's Letter"]:
+    article = None
+  elif item_name in ["Nayru's Pearl", "Din's Pearl", "Farore's Pearl"]:
+    article = None
   else:
     article = "the"
   if article:

--- a/tweaks.py
+++ b/tweaks.py
@@ -15,6 +15,7 @@ from wwlib import texture_utils
 from wwlib.rel import REL
 from wwrando_paths import ASSETS_PATH, ASM_PATH, SEEDGEN_PATH
 import customizer
+from logic.item_types import PROGRESS_ITEMS, NONPROGRESS_ITEMS, CONSUMABLE_ITEMS, DUPLICATABLE_CONSUMABLE_ITEMS
 
 try:
   from keys.seed_key import SEED_KEY
@@ -719,6 +720,31 @@ def get_indefinite_article(string):
     return "an"
   else:
     return "a"
+
+def add_article_before_item_name(item_name):
+  # Adds a grammatical article ("a", "an", "the", or nothing) in front an item's name.
+  article = None
+  if re.search(r"\d$", item_name):
+    article = None
+  elif (PROGRESS_ITEMS + NONPROGRESS_ITEMS).count(item_name) > 1:
+    article = get_indefinite_article(item_name)
+  elif item_name in CONSUMABLE_ITEMS:
+    article = get_indefinite_article(item_name)
+  elif item_name in DUPLICATABLE_CONSUMABLE_ITEMS:
+    article = get_indefinite_article(item_name)
+  elif item_name.endswith(" Key"):
+    article = get_indefinite_article(item_name)
+  elif item_name in ["Beedle's Chart", "Tingle's Chart", "Maggie's Letter"]:
+    article = None
+  elif item_name.endswith("'s Pearl"):
+    article = None
+  elif item_name in ["Father's Letter", "Moblin's Letter"]:
+    article = get_indefinite_article(item_name)
+  else:
+    article = "the"
+  if article:
+    item_name = article + " " + item_name
+  return item_name
 
 def upper_first_letter(string):
   first_letter = string[0].upper()

--- a/tweaks.py
+++ b/tweaks.py
@@ -1004,8 +1004,8 @@ def update_hoho_hints(self, hints):
     hint_lines = []
     for i, hint in enumerate(hints_for_hoho):
       # Determine the prefix and suffix for the hint
-      hint_prefix = "\\{1A 05 01 01 03}Ho ho! They say that " if i == 0 else "and that "
-      hint_suffix = "." if i == len(hints_for_hoho) - 1 else ","
+      hint_prefix = "\\{1A 05 01 01 03}Ho ho! To think that " if i == 0 else "and that "
+      hint_suffix = "..." if i == len(hints_for_hoho) - 1 else ","
       
       hint_lines.append(Hints.get_formatted_hint_text(hint, prefix=hint_prefix, suffix=hint_suffix))
       

--- a/tweaks.py
+++ b/tweaks.py
@@ -732,7 +732,7 @@ def add_article_before_item_name(item_name):
     article = get_indefinite_article(item_name)
   elif item_name in DUPLICATABLE_CONSUMABLE_ITEMS:
     article = get_indefinite_article(item_name)
-  elif item_name.endswith(" Key"):
+  elif item_name.lower().endswith(" small key"):
     article = get_indefinite_article(item_name)
   elif item_name in ["Beedle's Chart", "Tingle's Chart", "Maggie's Letter"]:
     article = None

--- a/tweaks.py
+++ b/tweaks.py
@@ -854,6 +854,9 @@ def update_item_names_in_letter_advertising_rock_spire_shop(self):
 def update_savage_labyrinth_hint_tablet(self, floor_30_hint, floor_50_hint):
   # Update the tablet on the first floor of savage labyrinth to give hints as to the items inside the labyrinth.
   
+  if self.dry_run:
+    return
+  
   if floor_30_hint and floor_50_hint:
     hint = "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_30_hint.info1
     hint += " and "
@@ -922,6 +925,9 @@ def randomize_and_update_hints(self):
       print("Invalid hint placement option: %s" % hint_placement)
 
 def update_fishmen_hints(self, hints):
+  if self.dry_run:
+    return
+  
   islands = list(range(1, 49+1))
   self.rng.shuffle(islands)
   
@@ -949,6 +955,9 @@ def update_fishmen_hints(self, hints):
     msg.string = hint
 
 def update_hoho_hints(self, hints):
+  if self.dry_run:
+    return
+  
   hohos = list(range(10))
   self.rng.shuffle(hohos)
   
@@ -989,6 +998,9 @@ def update_hoho_hints(self, hints):
     msg.string = hint
 
 def update_korl_hints(self, hints):
+  if self.dry_run:
+    return
+  
   hint_lines = []
   for i, hint in enumerate(hints):
     # Have no delay with KoRL text since he potentially has a lot of textboxes
@@ -1007,6 +1019,9 @@ def update_korl_hints(self, hints):
     msg.string = hint
 
 def update_big_octo_great_fairy_item_name_hint(self, hint):
+  if self.dry_run:
+    return
+  
   self.bmg.messages_by_id[12015].string = word_wrap_string(
     "\\{1A 06 FF 00 00 05}In \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 05}, you will find an item." % hint.info2,
     max_line_length=43

--- a/tweaks.py
+++ b/tweaks.py
@@ -986,7 +986,7 @@ def update_fishmen_hints(self, hints):
     
     hint = ""
     for hint_line in hint_lines:
-      hint_line = word_wrap_string(hint_line, max_line_length=43)
+      hint_line = word_wrap_string(hint_line, max_line_length=42)
       hint_line = pad_string_to_next_4_lines(hint_line)
       hint += hint_line
     
@@ -1030,7 +1030,7 @@ def update_hoho_hints(self, hints):
     
     hint = ""
     for hint_line in hint_lines:
-      hint_line = word_wrap_string(hint_line, max_line_length=43)
+      hint_line = word_wrap_string(hint_line, max_line_length=42)
       hint_line = pad_string_to_next_4_lines(hint_line)
       hint += hint_line
     
@@ -1052,7 +1052,7 @@ def update_korl_hints(self, hints):
   
   hint = ""
   for hint_line in hint_lines:
-    hint_line = word_wrap_string(hint_line, max_line_length=43)
+    hint_line = word_wrap_string(hint_line, max_line_length=42)
     hint_line = pad_string_to_next_4_lines(hint_line)
     hint += hint_line
   

--- a/tweaks.py
+++ b/tweaks.py
@@ -884,19 +884,19 @@ def update_savage_labyrinth_hint_tablet(self, floor_30_hint, floor_50_hint):
     return
   
   if floor_30_hint and floor_50_hint:
-    hint = "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_30_hint.info1
+    hint = "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_30_hint.reward
     hint += " and "
-    hint += "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_50_hint.info1
+    hint += "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_50_hint.reward
     hint += " await"
   elif floor_30_hint:
-    hint = "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_30_hint.info1
+    hint = "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_30_hint.reward
     hint += " and "
     hint += "challenge"
     hint += " await"
   elif floor_50_hint:
     hint = "challenge"
     hint += " and "
-    hint += "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_50_hint.info1
+    hint += "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_50_hint.reward
     hint += " await"
   else:
     hint = "challenge"
@@ -1049,11 +1049,11 @@ def update_big_octo_great_fairy_item_name_hint(self, hint):
     return
   
   self.bmg.messages_by_id[12015].string = word_wrap_string(
-    "\\{1A 06 FF 00 00 05}In \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 05}, you will find an item." % hint.info2,
+    "\\{1A 06 FF 00 00 05}In \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 05}, you will find an item." % hint.place,
     max_line_length=43
   )
   self.bmg.messages_by_id[12016].string = word_wrap_string(
-    "\\{1A 06 FF 00 00 05}...\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 05} which may help you on your quest." % upper_first_letter(hint.info1),
+    "\\{1A 06 FF 00 00 05}...\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 05} which may help you on your quest." % upper_first_letter(hint.reward),
     max_line_length=43
   )
   self.bmg.messages_by_id[12017].string = word_wrap_string(

--- a/tweaks.py
+++ b/tweaks.py
@@ -977,7 +977,7 @@ def update_fishmen_hints(self, hints):
     hint_lines = []
     hint_lines.append(Hints.get_formatted_hint_text(hint, prefix="I've heard from my sources that ", suffix=".", delay=60))
     
-    if not self.options.get("clearer_hints") and (hint.type == HintType.ITEM or hint.type == HintType.LOCATION):
+    if self.options.get("cryptic_hints") and (hint.type == HintType.ITEM or hint.type == HintType.LOCATION):
       hint_lines.append("Could be worth a try checking that place out. If you know where it is, of course.")
     
       if self.options.get("instant_text_boxes"):

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -142,7 +142,7 @@ OPTIONS = OrderedDict([
   ),
   (
     "clearer_hints",
-    "When this option is selected, location and item hints will use the standard location names and item names, instead of using cryptic hints.",
+    "When this option is selected, all hints will use the standard location names and item names, instead of using cryptic hints.",
   ),
   (
     "use_always_hints",

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -126,11 +126,11 @@ OPTIONS = OrderedDict([
   ),
   (
     "num_path_hints",
-    "The number of path hints that will be placed. Path hints tell you when an area contains an item that is definitely required to reach a particular destination in this seed.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
+    "The number of path hints that will be placed. Path hints tell you that an area contains an item that is logically required to reach a particular goal in this seed.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
   ),
   (
     "num_barren_hints",
-    "The number of barren hints that will be placed. Barren hints tell you when an area does not contain any required items in this seed.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
+    "The number of barren hints that will be placed. Barren hints tell you that an area does not contain any required items in this seed.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
   ),
   (
     "num_location_hints",
@@ -142,11 +142,11 @@ OPTIONS = OrderedDict([
   ),
   (
     "clearer_hints",
-    "When this option is selected, location and item hints will use the standard location or item name, instead of using cryptic hints.",
+    "When this option is selected, location and item hints will use the standard location names and item names, instead of using cryptic hints.",
   ),
   (
     "use_always_hints",
-    "When the number of location hints selected is set high enough, certain time-consuming locations will always be hinted at, taking precedence over normal location hints.",
+    "When this option is selected, certain time-consuming locations will take precedence over normal location hints.",
   ),
   
   

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -145,8 +145,8 @@ OPTIONS = OrderedDict([
     "When this option is selected, all hints will be phrased cryptically instead of telling you the names of locations and items directly.",
   ),
   (
-    "use_always_hints",
-    "When this option is selected, certain time-consuming locations will take precedence over normal location hints.",
+    "prioritize_remote_hints",
+    "When this option is selected, certain locations that are out of the way and time-consuming to complete will take precedence over normal location hints.",
   ),
   
   

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -126,27 +126,27 @@ OPTIONS = OrderedDict([
   ),
   (
     "num_path_hints",
-    "Determines the number of path hints that will be placed in the game, distributed among the selected hint placement options.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
+    "The number of path hints that will be placed. Path hints tell you when an area contains an item that is definitely required to reach a particular destination in this seed.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
   ),
   (
     "num_barren_hints",
-    "Determines the number of barren hints that will be placed in the game, distributed among the selected hint placement options.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
+    "The number of barren hints that will be placed. Barren hints tell you when an area does not contain any required items in this seed.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
   ),
   (
     "num_location_hints",
-    "Determines the number of location hints that will be placed in the game, distributed among the selected hint placement options.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
+    "The number of location hints that will be placed. Location hints tell you what item is at a specific location in this seed.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
   ),
   (
     "num_item_hints",
-    "Determines the number of item hints that will be placed in the game, distributed among the selected hint placement options.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
+    "The number of item hints that will be placed. Item hints tell you which area contains a particular progression item in this seed.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
   ),
   (
     "clearer_hints",
-    "When this option is selected, location and item hints will use the standard check or item name, instead of using cryptic hints.",
+    "When this option is selected, location and item hints will use the standard location or item name, instead of using cryptic hints.",
   ),
   (
     "use_always_hints",
-    "When the number of location hints is nonzero, certain locations that will always be hinted at will take precedence over normal location hints.",
+    "When the number of location hints selected is set high enough, certain time-consuming locations will always be hinted at, taking precedence over normal location hints.",
   ),
   
   

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -141,8 +141,8 @@ OPTIONS = OrderedDict([
     "The number of item hints that will be placed. Item hints tell you which area contains a particular progression item in this seed.\nIf multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
   ),
   (
-    "clearer_hints",
-    "When this option is selected, all hints will use the standard location names and item names, instead of using cryptic hints.",
+    "cryptic_hints",
+    "When this option is selected, all hints will be phrased cryptically instead of telling you the names of locations and items directly.",
   ),
   (
     "use_always_hints",

--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -990,7 +990,7 @@ class WWRandomizerWindow(QMainWindow):
       should_enable_options["num_race_mode_dungeons"] = False
     
     if self.get_option_value("num_location_hints") == 0:
-      should_enable_options["use_always_hints"] = False
+      should_enable_options["prioritize_remote_hints"] = False
     
     self.filtered_rgear.setFilterStrings(items_to_filter_out)
     

--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -269,6 +269,10 @@ class WWRandomizerWindow(QMainWindow):
             next_option_description, options_finished = next(randomizer_generator)
             if options_finished == -1:
               break
+        except (TooFewProgressionLocationsError, InvalidCleanISOError) as e:
+          error_message = str(e)
+          self.randomization_failed(error_message)
+          return
         except Exception as e:
           stack_trace = traceback.format_exc()
           error_message = "Error on seed " + temp_seed + ":\n" + str(e) + "\n\n" + stack_trace

--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -985,6 +985,9 @@ class WWRandomizerWindow(QMainWindow):
     else:
       should_enable_options["num_race_mode_dungeons"] = False
     
+    if self.get_option_value("num_location_hints") == 0:
+      should_enable_options["use_always_hints"] = False
+    
     self.filtered_rgear.setFilterStrings(items_to_filter_out)
     
     starting_gear = self.get_option_value("starting_gear")

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -893,9 +893,9 @@
                 </widget>
                </item>
                <item row="6" column="1">
-                <widget class="QCheckBox" name="use_always_hints">
+                <widget class="QCheckBox" name="prioritize_remote_hints">
                  <property name="text">
-                  <string>Use Always Hints</string>
+                  <string>Prioritize Remote Location Hints</string>
                  </property>
                 </widget>
                </item>

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -937,9 +937,12 @@
                 </layout>
                </item>
                <item row="6" column="0">
-                <widget class="QCheckBox" name="clearer_hints">
+                <widget class="QCheckBox" name="cryptic_hints">
                  <property name="text">
-                  <string>Clearer Hints</string>
+                  <string>Use Cryptic Text for Hints</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -974,7 +974,7 @@
                     <number>15</number>
                    </property>
                    <property name="value">
-                    <number>0</number>
+                    <number>5</number>
                    </property>
                   </widget>
                  </item>

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -882,35 +882,22 @@
                <string>Hint Options</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_7">
-               <item row="5" column="2">
-                <layout class="QHBoxLayout" name="horizontalLayout_17">
-                 <item>
-                  <widget class="QLabel" name="label_for_num_location_hints">
-                   <property name="text">
-                    <string>Location Hints</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="num_location_hints">
-                   <property name="correctionMode">
-                    <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
-                   </property>
-                   <property name="minimum">
-                    <number>0</number>
-                   </property>
-                   <property name="maximum">
-                    <number>15</number>
-                   </property>
-                   <property name="value">
-                    <number>0</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QWidget" name="widget_8" native="true"/>
-                 </item>
-                </layout>
+               <item row="4" column="0">
+                <widget class="QCheckBox" name="hoho_hints">
+                 <property name="text">
+                  <string>Place Hints on Old Man Ho Ho</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QCheckBox" name="use_always_hints">
+                 <property name="text">
+                  <string>Use Always Hints</string>
+                 </property>
+                </widget>
                </item>
                <item row="4" column="2">
                 <widget class="QCheckBox" name="korl_hints">
@@ -919,17 +906,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="4" column="0">
-                <widget class="QCheckBox" name="fishmen_hints">
-                 <property name="text">
-                  <string>Place Hints on Fishmen</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="1">
+               <item row="5" column="2">
                 <layout class="QHBoxLayout" name="horizontalLayout_16">
                  <item>
                   <widget class="QLabel" name="label_for_num_barren_hints">
@@ -959,27 +936,34 @@
                  </item>
                 </layout>
                </item>
-               <item row="4" column="1">
-                <widget class="QCheckBox" name="hoho_hints">
+               <item row="6" column="0">
+                <widget class="QCheckBox" name="clearer_hints">
                  <property name="text">
-                  <string>Place Hints on Old Man Ho Ho</string>
+                  <string>Clearer Hints</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QCheckBox" name="fishmen_hints">
+                 <property name="text">
+                  <string>Place Hints on Fishmen</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_15">
+               <item row="5" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_17">
                  <item>
-                  <widget class="QLabel" name="label_for_num_path_hints">
+                  <widget class="QLabel" name="label_for_num_location_hints">
                    <property name="text">
-                    <string>Path Hints</string>
+                    <string>Location Hints</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QSpinBox" name="num_path_hints">
+                  <widget class="QSpinBox" name="num_location_hints">
                    <property name="correctionMode">
                     <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
                    </property>
@@ -995,11 +979,11 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QWidget" name="widget_6" native="true"/>
+                  <widget class="QWidget" name="widget_8" native="true"/>
                  </item>
                 </layout>
                </item>
-               <item row="5" column="3">
+               <item row="5" column="0">
                 <layout class="QHBoxLayout" name="horizontalLayout_9">
                  <item>
                   <widget class="QLabel" name="label_for_num_item_hints">
@@ -1029,19 +1013,35 @@
                  </item>
                 </layout>
                </item>
-               <item row="6" column="1">
-                <widget class="QCheckBox" name="use_always_hints">
-                 <property name="text">
-                  <string>Use Always Hints</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QCheckBox" name="clearer_hints">
-                 <property name="text">
-                  <string>Clearer Hints</string>
-                 </property>
-                </widget>
+               <item row="5" column="3">
+                <layout class="QHBoxLayout" name="horizontalLayout_15">
+                 <item>
+                  <widget class="QLabel" name="label_for_num_path_hints">
+                   <property name="text">
+                    <string>Path Hints</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QSpinBox" name="num_path_hints">
+                   <property name="correctionMode">
+                    <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                   </property>
+                   <property name="minimum">
+                    <number>0</number>
+                   </property>
+                   <property name="maximum">
+                    <number>15</number>
+                   </property>
+                   <property name="value">
+                    <number>0</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="widget_6" native="true"/>
+                 </item>
+                </layout>
                </item>
               </layout>
              </widget>

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -621,10 +621,11 @@ class Ui_MainWindow(object):
 
         self.gridLayout_7.addLayout(self.horizontalLayout_16, 5, 2, 1, 1)
 
-        self.clearer_hints = QCheckBox(self.groupBox_5)
-        self.clearer_hints.setObjectName(u"clearer_hints")
+        self.cryptic_hints = QCheckBox(self.groupBox_5)
+        self.cryptic_hints.setObjectName(u"cryptic_hints")
+        self.cryptic_hints.setChecked(True)
 
-        self.gridLayout_7.addWidget(self.clearer_hints, 6, 0, 1, 1)
+        self.gridLayout_7.addWidget(self.cryptic_hints, 6, 0, 1, 1)
 
         self.fishmen_hints = QCheckBox(self.groupBox_5)
         self.fishmen_hints.setObjectName(u"fishmen_hints")
@@ -1030,7 +1031,7 @@ class Ui_MainWindow(object):
         self.use_always_hints.setText(QCoreApplication.translate("MainWindow", u"Use Always Hints", None))
         self.korl_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on King of Red Lions", None))
         self.label_for_num_barren_hints.setText(QCoreApplication.translate("MainWindow", u"Barren Hints", None))
-        self.clearer_hints.setText(QCoreApplication.translate("MainWindow", u"Clearer Hints", None))
+        self.cryptic_hints.setText(QCoreApplication.translate("MainWindow", u"Use Cryptic Text for Hints", None))
         self.fishmen_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Fishmen", None))
         self.label_for_num_location_hints.setText(QCoreApplication.translate("MainWindow", u"Location Hints", None))
         self.label_for_num_item_hints.setText(QCoreApplication.translate("MainWindow", u"Item Hints", None))

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -587,10 +587,10 @@ class Ui_MainWindow(object):
 
         self.gridLayout_7.addWidget(self.hoho_hints, 4, 0, 1, 1)
 
-        self.use_always_hints = QCheckBox(self.groupBox_5)
-        self.use_always_hints.setObjectName(u"use_always_hints")
+        self.prioritize_remote_hints = QCheckBox(self.groupBox_5)
+        self.prioritize_remote_hints.setObjectName(u"prioritize_remote_hints")
 
-        self.gridLayout_7.addWidget(self.use_always_hints, 6, 1, 1, 1)
+        self.gridLayout_7.addWidget(self.prioritize_remote_hints, 6, 1, 1, 1)
 
         self.korl_hints = QCheckBox(self.groupBox_5)
         self.korl_hints.setObjectName(u"korl_hints")
@@ -1028,7 +1028,7 @@ class Ui_MainWindow(object):
 
         self.groupBox_5.setTitle(QCoreApplication.translate("MainWindow", u"Hint Options", None))
         self.hoho_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Old Man Ho Ho", None))
-        self.use_always_hints.setText(QCoreApplication.translate("MainWindow", u"Use Always Hints", None))
+        self.prioritize_remote_hints.setText(QCoreApplication.translate("MainWindow", u"Prioritize Remote Location Hints", None))
         self.korl_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on King of Red Lions", None))
         self.label_for_num_barren_hints.setText(QCoreApplication.translate("MainWindow", u"Barren Hints", None))
         self.cryptic_hints.setText(QCoreApplication.translate("MainWindow", u"Use Cryptic Text for Hints", None))

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -581,40 +581,21 @@ class Ui_MainWindow(object):
         self.groupBox_5.setObjectName(u"groupBox_5")
         self.gridLayout_7 = QGridLayout(self.groupBox_5)
         self.gridLayout_7.setObjectName(u"gridLayout_7")
-        self.horizontalLayout_17 = QHBoxLayout()
-        self.horizontalLayout_17.setObjectName(u"horizontalLayout_17")
-        self.label_for_num_location_hints = QLabel(self.groupBox_5)
-        self.label_for_num_location_hints.setObjectName(u"label_for_num_location_hints")
+        self.hoho_hints = QCheckBox(self.groupBox_5)
+        self.hoho_hints.setObjectName(u"hoho_hints")
+        self.hoho_hints.setChecked(True)
 
-        self.horizontalLayout_17.addWidget(self.label_for_num_location_hints)
+        self.gridLayout_7.addWidget(self.hoho_hints, 4, 0, 1, 1)
 
-        self.num_location_hints = QSpinBox(self.groupBox_5)
-        self.num_location_hints.setObjectName(u"num_location_hints")
-        self.num_location_hints.setCorrectionMode(QAbstractSpinBox.CorrectToNearestValue)
-        self.num_location_hints.setMinimum(0)
-        self.num_location_hints.setMaximum(15)
-        self.num_location_hints.setValue(0)
+        self.use_always_hints = QCheckBox(self.groupBox_5)
+        self.use_always_hints.setObjectName(u"use_always_hints")
 
-        self.horizontalLayout_17.addWidget(self.num_location_hints)
-
-        self.widget_8 = QWidget(self.groupBox_5)
-        self.widget_8.setObjectName(u"widget_8")
-
-        self.horizontalLayout_17.addWidget(self.widget_8)
-
-
-        self.gridLayout_7.addLayout(self.horizontalLayout_17, 5, 2, 1, 1)
+        self.gridLayout_7.addWidget(self.use_always_hints, 6, 1, 1, 1)
 
         self.korl_hints = QCheckBox(self.groupBox_5)
         self.korl_hints.setObjectName(u"korl_hints")
 
         self.gridLayout_7.addWidget(self.korl_hints, 4, 2, 1, 1)
-
-        self.fishmen_hints = QCheckBox(self.groupBox_5)
-        self.fishmen_hints.setObjectName(u"fishmen_hints")
-        self.fishmen_hints.setChecked(True)
-
-        self.gridLayout_7.addWidget(self.fishmen_hints, 4, 0, 1, 1)
 
         self.horizontalLayout_16 = QHBoxLayout()
         self.horizontalLayout_16.setObjectName(u"horizontalLayout_16")
@@ -638,37 +619,42 @@ class Ui_MainWindow(object):
         self.horizontalLayout_16.addWidget(self.widget_7)
 
 
-        self.gridLayout_7.addLayout(self.horizontalLayout_16, 5, 1, 1, 1)
+        self.gridLayout_7.addLayout(self.horizontalLayout_16, 5, 2, 1, 1)
 
-        self.hoho_hints = QCheckBox(self.groupBox_5)
-        self.hoho_hints.setObjectName(u"hoho_hints")
-        self.hoho_hints.setChecked(True)
+        self.clearer_hints = QCheckBox(self.groupBox_5)
+        self.clearer_hints.setObjectName(u"clearer_hints")
 
-        self.gridLayout_7.addWidget(self.hoho_hints, 4, 1, 1, 1)
+        self.gridLayout_7.addWidget(self.clearer_hints, 6, 0, 1, 1)
 
-        self.horizontalLayout_15 = QHBoxLayout()
-        self.horizontalLayout_15.setObjectName(u"horizontalLayout_15")
-        self.label_for_num_path_hints = QLabel(self.groupBox_5)
-        self.label_for_num_path_hints.setObjectName(u"label_for_num_path_hints")
+        self.fishmen_hints = QCheckBox(self.groupBox_5)
+        self.fishmen_hints.setObjectName(u"fishmen_hints")
+        self.fishmen_hints.setChecked(True)
 
-        self.horizontalLayout_15.addWidget(self.label_for_num_path_hints)
+        self.gridLayout_7.addWidget(self.fishmen_hints, 4, 1, 1, 1)
 
-        self.num_path_hints = QSpinBox(self.groupBox_5)
-        self.num_path_hints.setObjectName(u"num_path_hints")
-        self.num_path_hints.setCorrectionMode(QAbstractSpinBox.CorrectToNearestValue)
-        self.num_path_hints.setMinimum(0)
-        self.num_path_hints.setMaximum(15)
-        self.num_path_hints.setValue(0)
+        self.horizontalLayout_17 = QHBoxLayout()
+        self.horizontalLayout_17.setObjectName(u"horizontalLayout_17")
+        self.label_for_num_location_hints = QLabel(self.groupBox_5)
+        self.label_for_num_location_hints.setObjectName(u"label_for_num_location_hints")
 
-        self.horizontalLayout_15.addWidget(self.num_path_hints)
+        self.horizontalLayout_17.addWidget(self.label_for_num_location_hints)
 
-        self.widget_6 = QWidget(self.groupBox_5)
-        self.widget_6.setObjectName(u"widget_6")
+        self.num_location_hints = QSpinBox(self.groupBox_5)
+        self.num_location_hints.setObjectName(u"num_location_hints")
+        self.num_location_hints.setCorrectionMode(QAbstractSpinBox.CorrectToNearestValue)
+        self.num_location_hints.setMinimum(0)
+        self.num_location_hints.setMaximum(15)
+        self.num_location_hints.setValue(0)
 
-        self.horizontalLayout_15.addWidget(self.widget_6)
+        self.horizontalLayout_17.addWidget(self.num_location_hints)
+
+        self.widget_8 = QWidget(self.groupBox_5)
+        self.widget_8.setObjectName(u"widget_8")
+
+        self.horizontalLayout_17.addWidget(self.widget_8)
 
 
-        self.gridLayout_7.addLayout(self.horizontalLayout_15, 5, 0, 1, 1)
+        self.gridLayout_7.addLayout(self.horizontalLayout_17, 5, 1, 1, 1)
 
         self.horizontalLayout_9 = QHBoxLayout()
         self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
@@ -692,17 +678,31 @@ class Ui_MainWindow(object):
         self.horizontalLayout_9.addWidget(self.widget_9)
 
 
-        self.gridLayout_7.addLayout(self.horizontalLayout_9, 5, 3, 1, 1)
+        self.gridLayout_7.addLayout(self.horizontalLayout_9, 5, 0, 1, 1)
 
-        self.use_always_hints = QCheckBox(self.groupBox_5)
-        self.use_always_hints.setObjectName(u"use_always_hints")
+        self.horizontalLayout_15 = QHBoxLayout()
+        self.horizontalLayout_15.setObjectName(u"horizontalLayout_15")
+        self.label_for_num_path_hints = QLabel(self.groupBox_5)
+        self.label_for_num_path_hints.setObjectName(u"label_for_num_path_hints")
 
-        self.gridLayout_7.addWidget(self.use_always_hints, 6, 1, 1, 1)
+        self.horizontalLayout_15.addWidget(self.label_for_num_path_hints)
 
-        self.clearer_hints = QCheckBox(self.groupBox_5)
-        self.clearer_hints.setObjectName(u"clearer_hints")
+        self.num_path_hints = QSpinBox(self.groupBox_5)
+        self.num_path_hints.setObjectName(u"num_path_hints")
+        self.num_path_hints.setCorrectionMode(QAbstractSpinBox.CorrectToNearestValue)
+        self.num_path_hints.setMinimum(0)
+        self.num_path_hints.setMaximum(15)
+        self.num_path_hints.setValue(0)
 
-        self.gridLayout_7.addWidget(self.clearer_hints, 6, 0, 1, 1)
+        self.horizontalLayout_15.addWidget(self.num_path_hints)
+
+        self.widget_6 = QWidget(self.groupBox_5)
+        self.widget_6.setObjectName(u"widget_6")
+
+        self.horizontalLayout_15.addWidget(self.widget_6)
+
+
+        self.gridLayout_7.addLayout(self.horizontalLayout_15, 5, 3, 1, 1)
 
 
         self.verticalLayout_8.addWidget(self.groupBox_5)
@@ -1026,15 +1026,15 @@ class Ui_MainWindow(object):
         self.num_race_mode_dungeons.setItemText(5, QCoreApplication.translate("MainWindow", u"6", None))
 
         self.groupBox_5.setTitle(QCoreApplication.translate("MainWindow", u"Hint Options", None))
-        self.label_for_num_location_hints.setText(QCoreApplication.translate("MainWindow", u"Location Hints", None))
-        self.korl_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on King of Red Lions", None))
-        self.fishmen_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Fishmen", None))
-        self.label_for_num_barren_hints.setText(QCoreApplication.translate("MainWindow", u"Barren Hints", None))
         self.hoho_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Old Man Ho Ho", None))
-        self.label_for_num_path_hints.setText(QCoreApplication.translate("MainWindow", u"Path Hints", None))
-        self.label_for_num_item_hints.setText(QCoreApplication.translate("MainWindow", u"Item Hints", None))
         self.use_always_hints.setText(QCoreApplication.translate("MainWindow", u"Use Always Hints", None))
+        self.korl_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on King of Red Lions", None))
+        self.label_for_num_barren_hints.setText(QCoreApplication.translate("MainWindow", u"Barren Hints", None))
         self.clearer_hints.setText(QCoreApplication.translate("MainWindow", u"Clearer Hints", None))
+        self.fishmen_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Fishmen", None))
+        self.label_for_num_location_hints.setText(QCoreApplication.translate("MainWindow", u"Location Hints", None))
+        self.label_for_num_item_hints.setText(QCoreApplication.translate("MainWindow", u"Item Hints", None))
+        self.label_for_num_path_hints.setText(QCoreApplication.translate("MainWindow", u"Path Hints", None))
         self.groupBox_6.setTitle(QCoreApplication.translate("MainWindow", u"Additional Advanced Options", None))
         self.do_not_generate_spoiler_log.setText(QCoreApplication.translate("MainWindow", u"Do Not Generate Spoiler Log", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab), QCoreApplication.translate("MainWindow", u"Advanced Options", None))

--- a/wwr_ui/ui_randomizer_window.py
+++ b/wwr_ui/ui_randomizer_window.py
@@ -644,7 +644,7 @@ class Ui_MainWindow(object):
         self.num_location_hints.setCorrectionMode(QAbstractSpinBox.CorrectToNearestValue)
         self.num_location_hints.setMinimum(0)
         self.num_location_hints.setMaximum(15)
-        self.num_location_hints.setValue(0)
+        self.num_location_hints.setValue(5)
 
         self.horizontalLayout_17.addWidget(self.num_location_hints)
 


### PR DESCRIPTION
This PR introduces three new hint types to the randomizer: path hints, barren hints, and location hints. We draw inspiration for these types of hints from other Zelda randomizers, mainly Ocarina of Time Randomizer. We describe the changes in detail below.

### What's The Same
To begin, we'll go over what hasn't changed. The hint placement options in fishmen, Old Man Ho Ho, and King of Red Lions have not changed, nor has the distribution behavior over these hint placement options. The hints you get from the stone tablet outside Savage Labyrinth, which hint at what is on floors 30 and 50, have not changed. The Wallet mail hint on the items that the Rock Spire Beedle Shop Ship sells has also remained the same. 

Previously, the randomizer used what we will call "item hints", which say that a particular island contains a specific item. These have changed slightly, which we will get into later, but they still exist in addition to the three new hint types. The Two-Eye Octo Fairy hint is an item hint, so it, too, has slightly changed. The user can select the number of each hint type from 0 to 15. The user cannot disable the Savage Labyrinth, Wallet mail, and Octo Fairy hints. So with that, let's introduce the new hint types.

### Path Hints
Path hints are the most complicated hint type, and we'll need to solidify some terminology beforehand.

A **zone** refers to an island, dungeon, the Mailbox region, or the Great Sea region. Each check belongs to a zone. For example, mail checks are in the Mailbox zone. Cyclos is in the Great Sea Zone. Gohma Heart Container is in the Dragon Roost Cavern zone. In this last example, note that the dungeon takes priority over the island. When caves are randomized, the zone of that check is the island where its entrance is. So, if Overlook cave is on Overlook Island, the zone for the check is Overlook Island. However, if Overlook cave is on Pawprint Isle, its zone is Pawprint Isle. Previous item hint implementation only used islands for hinting. So, if something was in Dragon Roost Cavern, the hint would point to Dragon Roost Island (assuming entrances are not randomized). Additionally, hints could not point to Mailbox, the Great Sea, Hyrule, or Ganon's Tower. The new hint types, as well as the item hints, now use the zone name rather than just the island name. There is one special case for zones: if Tower of the Gods leads to a randomized cave, or if something refers to the sunken treasure there, then "Tower of the Gods sector" will be used to differentiate from the dungeon of the same name.

A **progress item** is any item that logically opens up checks in the randomized seed. For example, Triforce shards, swords, and progressive bows are always progress items because reaching Ganondorf and beating him is logically expected in every seed. On the other hand, charts are only progress items if sunken treasure is on. Likewise, Maggie's Letter is only a progress item if Short Sidequests are on. Note that the Maggie's Letter check (Windfall Island - Cafe Bar - Postman) does not have to have a progress item for Maggie's Letter to be considered a progress item. The only condition is that *Windfall Island - Cafe Bar - Postman* is a logical check in that seed's settings.

A **path goal** could be any arbitrary condition in the game, but for path hints, path goals are either:
1. The completion of a race-mode dungeon.
2. The ability to enter Hyrule.
3. The ability to reach and defeat Ganondorf.

For race-mode dungeon path goals, the goal is written as "path to dungeon boss"; for example, a path to Gohma refers to the condition of being able to reach and defeat Gohma for the completion of Dragon Roost Cavern. For the ability to enter Hyrule, the goal is written as "path to Hyrule", and for the ability to reach and defeat Ganondorf, the goal is written as "path to Ganondorf". When race mode is on, only the selected race mode dungeons are valid goals, along with Hyrule and Ganondorf. When race mode is off, only Hyrule and Ganondorf are valid goals.

A **path item** to a path goal is any progress item logically required to achieve that path goal. We write that the item is "on the path to" that path goal. For example, the Grappling Hook is always on the path to Gohma. Likewise, the Triforce shards are always on both the path to Hyrule and the path to Ganondorf. For progressive items, such as bows and wallets, the path item is specific to an instance of that item, not all copies of that progressive item. For example, assume there is only one randomized shard (i.e., you start with seven shards). If that shard is in one of Lenzo's chests, you need one of the progressive Picto Boxes. The progressive Picto Box is a path item to Hyrule if and only if one Picto Box is locked behind the other. So, if there is one Picto Box on Tott and another in the other Lenzo chest, then the Picto Box from Tott is a path item (to Hyrule). However, if one Picto Box is on Tott and the other is on the Salvage Corps, then *neither* Picto Boxes are path items (to Hyrule). This is because you have "a choice" as to which Picto Box you use to reach the shard; therefore, neither is required to reach the path goal. You do need *a* Picto Box, but neither specific instance of a Picto Box is required.

<img src="https://user-images.githubusercontent.com/4733098/204984625-88829c2d-e538-479e-902b-7a66dbf86c75.PNG" width="500">

**Path hints** inform the player that a zone contains a path item on the path to a path goal. These path items are selected randomly by randomly picking a valid path goal, and then choosing a path item toward that path goal. When race mode is on, the randomizer tries first to ensure that each race mode dungeon is hinted once and then will select the path goal randomly for the remaining path hints. If an item is on multiple paths, the randomizer will prioritize race mode dungeons, then Hyrule, then Ganondorf. For example, you might get that Windfall Island is on the path to Jalhalla, meaning that a check on Windfall (i.e., on the Windfall zone) gives a path item on the path to Jalhalla. Each path hint always refers to a single item, but that item is unknown to the player. There may be several items on Windfall which are on the path to Jalhalla, which means the player could receive multiple path hints for Windfall to Jalhalla.

Path hints can allow the player to deduce things about the seed logically. For example, suppose you know (by process of elimination, for instance) that a bottle is on the path to Hyrule. In that case, you know that one of the checks locked behind the bottle will lead to a Triforce shard. It could be a direct path, such as a shard being on Grandma mail, or it could be the start of some long chain that eventually results in a shard. As another example, assume you know that the Deku Leaf is on the path to Gohma, that dungeon entrances are not randomized, that Tingle chests are not on, and that key-lunacy is not on. Suppose you find Grappling Hook on some open check, such as Tott. This means that (a) there's a Small Key in the Big Key chest and that (b) Fire and Ice Arrows are locked behind the Deku Leaf. The first deduction is because if there weren't a Small Key in the Big Key chest, you could beat the dungeon logically without the Deku Leaf. The second deduction is that if Fire and Ice Arrows were accessible without the Deku Leaf, it would provide an alternative method to reach the Big Key chest. By definition, a path item is required for that path goal, so if there are alternatives, the Deku Leaf would not be a path item.

Finally, the item on race mode dungeon bosses is never hinted at as path items. Therefore, if you get that Dragon Roost Cavern is on the path to Hyrule, this hint does not refer to the shard (for example) on Gohma Heart Container.

### Barren Hints
<img src="https://user-images.githubusercontent.com/4733098/204984562-6ce12264-2fb6-464d-b135-317237c911a4.PNG" width="500">

**Barren hints** inform the player that the hinted zone contains no path items. We say that the zone is "foolish" or "barren". For example, getting a barren hint for Hyrule means that the Master Sword chamber does not contain a path item. When a race mode dungeon is hinted at as being barren, it excludes the item you get from defeating the dungeon boss. This way, race mode dungeons can still be hinted barren if the rest of the dungeon contains no path items. Furthermore, any mail checks directly unlocked from defeating a barren dungeon are also barren. Non-race mode dungeons are never hinted barren. When entrances are randomized, remember that the zone refers to where the cave's entrance is. So, Overlook Island being hinted barren means that the cave at Overlook Island leads to a barren cave/dungeon. It does not necessarily mean that the Overlook combat cave is barren.

An intuitive way to think about barren hints is that they tell you that you never have to visit that location. Of course, this is a simplified interpretation since you may have to visit the island to complete a race mode dungeon or a sidequest like Goron Trading. The randomizer uses a weighted random selection to pick which barren locations to hint at. Each location is weighted by the square root of the number of checks there. For example, a barren dungeon is typically 3.5-4x more likely to be chosen than a barren location with only one check.

Barren hints can be used to cut down on the number of areas the player is required to visit within a single seed without compromising which settings are on. For example, having eye reefs might be an interesting setting, but doing all six might take a lot of work for every seed. So if you get a few barren hints for some eye reefs, you can still have the experience of doing eye reefs without it becoming too tedious.

### Location Hints
<img src="https://user-images.githubusercontent.com/4733098/204984557-3c6ba7d8-62ed-41b7-891c-18a4ffcdaf0f.PNG" width="500">

**Location hints** directly tell you about a specific check and what item is there. This item could be a progress item, a path item, or junk. Because of this, the hint will never use cryptic text for the item and will instead hint the item name directly (see [Clearer Hints](#clearer-hints) below). Location hints only hint at certain checks from the list here, and the randomizer selects which checks at random. Only checks which are in logic based on the seed's settings are valid location hints. For example, if Wind Temple is not a race mode dungeon, you will never get a location hint for a check in Wind Temple. The [list of location hints](https://github.com/tanjo3/wwrando/blob/0dc29e454c80fba8639909dfc965e64f9c6a4be4/data/location_hints.txt) was selected to include some of the more annoying and longer checks in the game. This gives each location hint more value than simply selecting checks at random. For example, we don't want to hint at each Free Gift check because that doesn't add anything to the gameplay experience.

Location hints are divided into two categories: sometimes and always. Always hints are a special type of location that will always be hinted, assuming that check is in logic. Always hints are not enabled by default, and can be enabled by checking the "Use Always Hint" setting. For example, Ganon's Maze chest is an always hint, which means that if that check is in logic (i.e., Dungeons is on), the "Use Always Hint" setting in on, and the player specifies to generate at least one location hint, the Ganon's Maze location will always be hinted. The remaining location hints are refered to as sometimes hints, as they will be hinted at sometimes, but not always. We chose the partciularly long and tedious checks to be classified as always hints. The categorization of each location hint can be found in the location hints file, referenced above.

### Item Hints
<img src="https://user-images.githubusercontent.com/4733098/204984518-fad86a4d-ef78-42b2-acb9-a99efa056ef4.PNG" width="500">

As mentioned at the start, item hints are the original implementation of hints in the randomizer and have been left largely the same. The only difference is that checks in the Mailbox, the Great Sea, Hyrule, and Ganon's Tower zones can now be hinted at. Note that this affects the Two-Eye Octo Great Fairy hint as well. Previously, only items on islands could be hinted at. Keeping consistent with the previous implementation, if an item is in a dungeon, it will use the island where the entrance is found for the hint location rather than the dungeon itself. The hint text for the new zones are:
* **Mailbox**: the mail
* **The Great Sea**: a location on the open seas
* **Hyrule**: the submerged castle
* **Ganon's Tower**: the stronghold of the evil king


### How Hints Work Together
An important property of the hints is that any particular item can only be hinted at once. So, for example, you can't get two path hints for the same item. So if, for example, you get two path hints for Windfall Island, they must necessarily refer to two different items. In addition, if you get a location hint for a check on Windfall, say that *Windfall Island - Mrs. Marie - Give 40 Joy Pendants* gives the Deku Leaf, you know that neither path hint can refer to that Deku Leaf. The Savage Labyrinth, Wallet mail, and Two-Eye Octo Great Fairy hints are exempt from this. In other words, a path hint for Rock Spire Isle might refer to one of the items that the Rock Spire Beedle Shop Ship is selling.

### Clearer Hints
<img src="https://user-images.githubusercontent.com/4733098/204984478-18192def-e289-4099-9690-964752c9e880.PNG" width="500">

Based on feedback from the randomizer racing community, we also added the option to enable clearer hints. This replaces the cryptic text in hints with the in-game name for that zone or item. This helps players who have dyslexia or whose native language is not English. Path and barren are always clear, and never use cryptic text. Location hints will always use clearer hints for the item name, regardless if this setting is disabled. Thus, this setting only affects the check name for location hints and the text used in item hints.

### Credits and Final Comments
We like to thank the entire Wind Waker randomizer racing community for their assistance in implementing this PR, both in terms of the technical development of the new hints and in their testing. There were indeed some interesting bugs along the way. The community recently successfully finished the [Season 5 Tournament](https://challonge.com/2kdg2d0o) which featured these new hint types. The Random Settings Tournament's inaugural season is also underway, which uses these hints in an interesting manner. For these races, the settings are randomized and unknown to all racers. Because you can only receive hints for checks which are in logic, the runners can use hints, in combination with Chest Type Matches Contents (CTMC), to logically deduce which settings are enabled to complete the seed efficiently.

Hopefully, that covers everything in this PR. I am open to comments and suggestions on how to improve the feature and how it has been implemented.