### PR TITLE
Fix some issues with dry runs

### DIFF
--- a/tweaks.py
+++ b/tweaks.py
@@ -14,7 +14,7 @@ from asm import patcher
 from wwlib import texture_utils
 from wwlib.rel import REL
 from wwlib.bmg import TextBoxType
-from wwrando_paths import ASSETS_PATH, ASM_PATH, SEEDGEN_PATH
+from wwrando_paths import ASSETS_PATH, ASM_PATH
 import customizer
 from logic.item_types import PROGRESS_ITEMS, NONPROGRESS_ITEMS, CONSUMABLE_ITEMS, DUPLICATABLE_CONSUMABLE_ITEMS
 
@@ -1648,27 +1648,6 @@ def make_tingle_statue_reward_rupee_rainbow_colored(self):
 def show_seed_hash_on_name_entry_screen(self):
   # Add some text to the name entry screen which has two random character names that vary based on the permalink (so the seed and settings both change it).
   # This is so two players intending to play the same seed can verify if they really are on the same seed or not.
-  
-  if not self.permalink:
-    return
-  
-  if not self.options.get("do_not_generate_spoiler_log"):
-    integer_seed = self.convert_string_to_integer_md5(self.permalink)
-  else:
-    # When no spoiler log is generated, the seed key also affects randomization, not just the data in the permalink.
-    integer_seed = self.convert_string_to_integer_md5(self.permalink + SEED_KEY)
-  temp_rng = Random()
-  temp_rng.seed(integer_seed)
-  
-  with open(os.path.join(SEEDGEN_PATH, "names.txt")) as f:
-    all_names = f.read().splitlines()
-  valid_names = [name for name in all_names if len(name) <= 5]
-  
-  name_1, name_2 = temp_rng.sample(valid_names, 2)
-  name_1 = upper_first_letter(name_1)
-  name_2 = upper_first_letter(name_2)
-  self.seed_hash = name_1 + " " + name_2
-  
   # Since actually adding new text to the UI would be very difficult, instead hijack the "Name Entry" text, and put the seed hash after several linebreaks.
   # (The three linebreaks we insert before "Name Entry" are so it's still in the correct spot after vertical centering happens.)
   msg = self.bmg.messages_by_id[40]

--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -41,6 +41,7 @@ class WWRandomizerWindow(QMainWindow):
     self.randomizer_thread = None
     
     self.cmd_line_args = cmd_line_args
+    self.dry_run = ("-dry" in cmd_line_args)
     self.bulk_test = ("-bulk" in cmd_line_args)
     self.no_ui_test = ("-noui" in cmd_line_args)
     self.profiling = ("-profile" in cmd_line_args)
@@ -223,7 +224,7 @@ class WWRandomizerWindow(QMainWindow):
     self.ui.clean_iso_path.setText(clean_iso_path)
     self.ui.output_folder.setText(output_folder)
     
-    if not os.path.isfile(clean_iso_path):
+    if not self.dry_run and not os.path.isfile(clean_iso_path):
       QMessageBox.warning(self, "Clean ISO path not specified", "Must specify path to your clean Wind Waker ISO (USA).")
       return
     if not os.path.isdir(output_folder):


### PR DESCRIPTION
- Don't show an error when clicking the "Randomize" button without a Clean ISO path specified if it's a dry run.
- Include the seed hash in the log files for a dry run.