### PR TITLE
UI Refresh

### DIFF
--- a/wwr_ui/build_ui.py
+++ b/wwr_ui/build_ui.py
@@ -11,6 +11,6 @@ for input_path in glob.glob(glob.escape(ui_dir) + "/*.ui"):
   command = [
     "pyside6-uic",
     input_path,
-    "-o", ui_dir + "uic/ui_%s.py" % base_name
+    "-o", ui_dir + "/uic/ui_%s.py" % base_name
   ]
   result = call(command)

--- a/wwr_ui/cosmetic_tab.ui
+++ b/wwr_ui/cosmetic_tab.ui
@@ -15,11 +15,11 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_14">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_10">
+    <layout class="QVBoxLayout" name="layoutV_for_0_cosmetic_options">
      <item>
-      <layout class="QGridLayout" name="gridLayout_5">
+      <layout class="QGridLayout" name="layoutG_for_0_model_settings">
        <item row="2" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <layout class="QHBoxLayout" name="layoutH_for_random_colors">
          <item>
           <widget class="QPushButton" name="randomize_all_custom_colors_together">
            <property name="text">
@@ -37,7 +37,7 @@
         </layout>
        </item>
        <item row="2" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <layout class="QHBoxLayout" name="layoutH_for_2_color_present">
          <item>
           <widget class="QLabel" name="label_for_custom_color_preset">
            <property name="text">
@@ -51,7 +51,7 @@
         </layout>
        </item>
        <item row="1" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <layout class="QHBoxLayout" name="layoutH_for_0_model">
          <item>
           <widget class="QLabel" name="label_for_custom_player_model">
            <property name="text">
@@ -65,7 +65,7 @@
         </layout>
        </item>
        <item row="1" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_13">
+        <layout class="QHBoxLayout" name="layoutH_for_1_custom_options">
          <item>
           <widget class="QCheckBox" name="player_in_casual_clothes">
            <property name="text">
@@ -121,7 +121,7 @@
       <layout class="QVBoxLayout" name="custom_colors_layout"/>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_18">
+      <layout class="QHBoxLayout" name="layoutH_for_1_present">
        <item>
         <widget class="QPushButton" name="save_custom_color_preset">
          <property name="text">
@@ -139,7 +139,7 @@
       </layout>
      </item>
      <item>
-      <spacer name="verticalSpacer_4">
+      <spacer name="zzzz_spacerV_for_cosmetic_options">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
@@ -154,7 +154,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_11">
+    <layout class="QVBoxLayout" name="layoutV_for_1_preview">
      <item>
       <widget class="QLabel" name="custom_model_preview_label">
        <property name="sizePolicy">
@@ -175,7 +175,7 @@
       </widget>
      </item>
      <item>
-      <spacer name="verticalSpacer_5">
+      <spacer name="zzzz_spacerV_for_preview">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -16,7 +16,7 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QScrollArea" name="scrollArea">
+     <widget class="QScrollArea" name="layoutS_for_0_primary">
       <property name="minimumSize">
        <size>
         <width>600</width>
@@ -32,13 +32,13 @@
       <property name="widgetResizable">
        <bool>true</bool>
       </property>
-      <widget class="QWidget" name="scrollAreaWidgetContents">
+      <widget class="QWidget" name="scrollA_for_primary">
        <property name="geometry">
         <rect>
          <x>0</x>
          <y>0</y>
          <width>870</width>
-         <height>582</height>
+         <height>608</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -46,7 +46,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QTabWidget" name="tabWidget">
+         <widget class="QTabWidget" name="tabs_for_primary">
           <property name="enabled">
            <bool>true</bool>
           </property>
@@ -59,7 +59,7 @@
            </attribute>
            <layout class="QVBoxLayout" name="verticalLayout_3">
             <item>
-             <layout class="QGridLayout" name="gridLayout">
+             <layout class="QGridLayout" name="layoutG_for_0_paths">
               <item row="2" column="1">
                <widget class="QLineEdit" name="seed"/>
               </item>
@@ -122,51 +122,6 @@
                <string>Progression Locations: Where Should Progress Items Be Placed?</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_2">
-               <item row="1" column="4">
-                <widget class="QCheckBox" name="progression_platforms_rafts">
-                 <property name="text">
-                  <string>Lookout Platforms and Rafts</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QCheckBox" name="progression_expensive_purchases">
-                 <property name="text">
-                  <string>Expensive Purchases</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="progression_dungeon_secrets">
-                 <property name="text">
-                  <string>Dungeon Secrets</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="3" colspan="2">
-                <widget class="QCheckBox" name="progression_treasure_charts">
-                 <property name="text">
-                  <string>Sunken Treasure (From Treasure Charts)</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QCheckBox" name="progression_tingle_chests">
-                 <property name="text">
-                  <string>Tingle Chests</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <widget class="QCheckBox" name="progression_savage_labyrinth">
-                 <property name="text">
-                  <string>Savage Labyrinth</string>
-                 </property>
-                </widget>
-               </item>
                <item row="0" column="0">
                 <widget class="QCheckBox" name="progression_dungeons">
                  <property name="text">
@@ -177,92 +132,10 @@
                  </property>
                 </widget>
                </item>
-               <item row="6" column="1" colspan="2">
-                <widget class="QCheckBox" name="progression_triforce_charts">
-                 <property name="text">
-                  <string>Sunken Treasure (From Triforce Charts)</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QCheckBox" name="progression_combat_secret_caves">
-                 <property name="text">
-                  <string>Combat Secret Caves</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="4">
-                <widget class="QCheckBox" name="progression_big_octos_gunboats">
-                 <property name="text">
-                  <string>Big Octos and Gunboats</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="4">
-                <widget class="QCheckBox" name="progression_island_puzzles">
-                 <property name="text">
-                  <string>Island Puzzles</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="2">
-                <widget class="QCheckBox" name="progression_great_fairies">
-                 <property name="text">
-                  <string>Great Fairies</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
                <item row="0" column="1">
-                <widget class="QCheckBox" name="progression_puzzle_secret_caves">
+                <widget class="QCheckBox" name="progression_tingle_chests">
                  <property name="text">
-                  <string>Puzzle Secret Caves</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="2">
-                <widget class="QCheckBox" name="progression_battlesquid">
-                 <property name="text">
-                  <string>Battlesquid Minigame</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="1">
-                <widget class="QCheckBox" name="progression_minigames">
-                 <property name="text">
-                  <string>Minigames</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QCheckBox" name="progression_misc">
-                 <property name="text">
-                  <string>Miscellaneous</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QCheckBox" name="progression_submarines">
-                 <property name="text">
-                  <string>Submarines</string>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QCheckBox" name="progression_short_sidequests">
-                 <property name="text">
-                  <string>Short Sidequests</string>
+                  <string>Tingle Chests</string>
                  </property>
                 </widget>
                </item>
@@ -280,14 +153,138 @@
                  </property>
                 </widget>
                </item>
-               <item row="4" column="3">
-                <widget class="QCheckBox" name="progression_eye_reef_chests">
+               <item row="4" column="0">
+                <widget class="QCheckBox" name="progression_short_sidequests">
                  <property name="text">
-                  <string>Eye Reef Chests</string>
+                  <string>Short Sidequests</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="3">
+               <item row="1" column="0">
+                <widget class="QCheckBox" name="progression_puzzle_secret_caves">
+                 <property name="text">
+                  <string>Puzzle Secret Caves</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QCheckBox" name="progression_savage_labyrinth">
+                 <property name="text">
+                  <string>Savage Labyrinth</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="progression_combat_secret_caves">
+                 <property name="text">
+                  <string>Combat Secret Caves</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QCheckBox" name="progression_dungeon_secrets">
+                 <property name="text">
+                  <string>Dungeon Secrets</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="3">
+                <widget class="QCheckBox" name="progression_battlesquid">
+                 <property name="text">
+                  <string>Battlesquid Minigame</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QCheckBox" name="progression_mail">
+                 <property name="text">
+                  <string>Mail</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="3">
+                <widget class="QCheckBox" name="progression_great_fairies">
+                 <property name="text">
+                  <string>Great Fairies</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0" colspan="4">
+                <layout class="QHBoxLayout" name="z_layoutH_for_z_bottom">
+                 <item>
+                  <widget class="QCheckBox" name="progression_misc">
+                   <property name="text">
+                    <string>Miscellaneous</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="progression_treasure_charts">
+                   <property name="text">
+                    <string>Sunken Treasure (From Treasure Charts)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="progression_triforce_charts">
+                   <property name="text">
+                    <string>Sunken Treasure (From Triforce Charts)</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item row="4" column="3">
+                <widget class="QCheckBox" name="progression_expensive_purchases">
+                 <property name="text">
+                  <string>Expensive Purchases</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <widget class="QCheckBox" name="progression_minigames">
+                 <property name="text">
+                  <string>Minigames</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QCheckBox" name="progression_submarines">
+                 <property name="text">
+                  <string>Submarines</string>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QCheckBox" name="progression_big_octos_gunboats">
+                 <property name="text">
+                  <string>Big Octos and Gunboats</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="2">
+                <widget class="QCheckBox" name="progression_platforms_rafts">
+                 <property name="text">
+                  <string>Lookout Platforms and Rafts</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
                 <widget class="QCheckBox" name="progression_free_gifts">
                  <property name="text">
                   <string>Free Gifts</string>
@@ -297,10 +294,17 @@
                  </property>
                 </widget>
                </item>
-               <item row="5" column="4">
-                <widget class="QCheckBox" name="progression_mail">
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="progression_island_puzzles">
                  <property name="text">
-                  <string>Mail</string>
+                  <string>Island Puzzles</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="3">
+                <widget class="QCheckBox" name="progression_eye_reef_chests">
+                 <property name="text">
+                  <string>Eye Reef Chests</string>
                  </property>
                 </widget>
                </item>
@@ -308,13 +312,13 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_2">
+             <widget class="QGroupBox" name="layoutG_for_2_item_randomizers">
               <property name="title">
                <string>Item Randomizer Modes</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_3">
                <item row="0" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_3">
+                <layout class="QHBoxLayout" name="layoutH_for_0_sword_mode">
                  <item>
                   <widget class="QLabel" name="label_for_sword_mode">
                    <property name="text">
@@ -350,7 +354,7 @@
                 </layout>
                </item>
                <item row="0" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <layout class="QHBoxLayout" name="layoutH_for_1_triforce_shards">
                  <item>
                   <widget class="QLabel" name="label_for_num_starting_triforce_shards">
                    <property name="sizePolicy">
@@ -454,45 +458,17 @@
              </widget>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_19">
+             <layout class="QHBoxLayout" name="layoutH_for_3_randomizers">
               <item>
-               <widget class="QGroupBox" name="groupBox_7">
+               <widget class="QGroupBox" name="layoutG_for_0_entrance">
                 <property name="title">
                  <string>Entrance Randomizer Options</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_9">
-                 <item row="0" column="2">
-                  <widget class="QCheckBox" name="randomize_miniboss_entrances">
-                   <property name="text">
-                    <string>Nested Minibosses</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QCheckBox" name="randomize_dungeon_entrances">
-                   <property name="text">
-                    <string>Dungeons</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QCheckBox" name="randomize_secret_cave_entrances">
-                   <property name="text">
-                    <string>Secret Caves</string>
-                   </property>
-                  </widget>
-                 </item>
                  <item row="0" column="1">
                   <widget class="QCheckBox" name="randomize_boss_entrances">
                    <property name="text">
                     <string>Nested Bosses</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QCheckBox" name="randomize_secret_cave_inner_entrances">
-                   <property name="text">
-                    <string>Inner Secret Caves</string>
                    </property>
                   </widget>
                  </item>
@@ -503,8 +479,36 @@
                    </property>
                   </widget>
                  </item>
+                 <item row="1" column="1">
+                  <widget class="QCheckBox" name="randomize_secret_cave_inner_entrances">
+                   <property name="text">
+                    <string>Inner Secret Caves</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QCheckBox" name="randomize_secret_cave_entrances">
+                   <property name="text">
+                    <string>Secret Caves</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0">
+                  <widget class="QCheckBox" name="randomize_dungeon_entrances">
+                   <property name="text">
+                    <string>Dungeons</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="2">
+                  <widget class="QCheckBox" name="randomize_miniboss_entrances">
+                   <property name="text">
+                    <string>Nested Minibosses</string>
+                   </property>
+                  </widget>
+                 </item>
                  <item row="2" column="0" colspan="3">
-                  <layout class="QHBoxLayout" name="horizontalLayout_5">
+                  <layout class="QHBoxLayout" name="layoutH_for_0_mix">
                    <item>
                     <widget class="QLabel" name="label_for_mix_entrances">
                      <property name="text">
@@ -538,7 +542,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QGroupBox" name="groupBox_8">
+               <widget class="QGroupBox" name="layoutG_for_1_other">
                 <property name="title">
                  <string>Other Randomizers</string>
                 </property>
@@ -580,7 +584,7 @@
              </layout>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_3">
+             <widget class="QGroupBox" name="layoutG_for_4_convenience">
               <property name="title">
                <string>Convenience Tweaks</string>
               </property>
@@ -667,7 +671,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="verticalSpacer_7">
+             <spacer name="zzzz_spacerV_for_randomizer_settings">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
@@ -690,9 +694,9 @@
            </attribute>
            <layout class="QVBoxLayout" name="verticalLayout_4">
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_6">
+             <layout class="QHBoxLayout" name="layoutH_for_0_gear">
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_5">
+               <layout class="QVBoxLayout" name="layoutV_for_0_randomized_gear">
                 <item>
                  <widget class="QLabel" name="label_for_randomized_gear">
                   <property name="text">
@@ -713,7 +717,7 @@
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_6">
+               <layout class="QVBoxLayout" name="layoutV_for_1_gear_buttons">
                 <item>
                  <spacer name="verticalSpacer">
                   <property name="orientation">
@@ -769,7 +773,7 @@
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_7">
+               <layout class="QVBoxLayout" name="layoutV_for_2_starting_gear">
                 <item>
                  <widget class="QLabel" name="label_for_starting_gear">
                   <property name="text">
@@ -792,7 +796,7 @@
              </layout>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_7">
+             <layout class="QHBoxLayout" name="layoutH_for_1_health">
               <item>
                <widget class="QLabel" name="label_for_starting_hcs">
                 <property name="text">
@@ -844,7 +848,7 @@
                </widget>
               </item>
               <item>
-               <spacer name="horizontalSpacer_3">
+               <spacer name="zzzz_spacerH_for_health">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
@@ -866,7 +870,7 @@
            </attribute>
            <layout class="QVBoxLayout" name="verticalLayout_8">
             <item>
-             <widget class="QGroupBox" name="groupBox_4">
+             <widget class="QGroupBox" name="layoutG_for_0_bosses">
               <property name="title">
                <string>Required Bosses</string>
               </property>
@@ -879,7 +883,7 @@
                 </widget>
                </item>
                <item row="0" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_8">
+                <layout class="QHBoxLayout" name="layoutH_for_0_bosses">
                  <item>
                   <widget class="QLabel" name="label_for_num_required_bosses">
                    <property name="sizePolicy">
@@ -957,13 +961,13 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_9">
+             <widget class="QGroupBox" name="layoutG_for_1_logic">
               <property name="title">
                <string>Logic Difficulty</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_22">
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_20">
+                <layout class="QHBoxLayout" name="layoutH_for_0_obscurity">
                  <item>
                   <widget class="QLabel" name="label_for_logic_obscurity">
                    <property name="text">
@@ -998,7 +1002,7 @@
                 </layout>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_21">
+                <layout class="QHBoxLayout" name="layoutH_for_1_precision">
                  <item>
                   <widget class="QLabel" name="label_for_logic_precision">
                    <property name="text">
@@ -1042,7 +1046,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_5">
+             <widget class="QGroupBox" name="layoutG_for_2_hints">
               <property name="title">
                <string>Hint Options</string>
               </property>
@@ -1072,7 +1076,7 @@
                 </widget>
                </item>
                <item row="5" column="2">
-                <layout class="QHBoxLayout" name="horizontalLayout_16">
+                <layout class="QHBoxLayout" name="layoutH_for_2_barren_hints">
                  <item>
                   <widget class="QLabel" name="label_for_num_barren_hints">
                    <property name="text">
@@ -1122,7 +1126,7 @@
                 </widget>
                </item>
                <item row="5" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_17">
+                <layout class="QHBoxLayout" name="layoutH_for_1_location_hints">
                  <item>
                   <widget class="QLabel" name="label_for_num_location_hints">
                    <property name="text">
@@ -1152,7 +1156,7 @@
                 </layout>
                </item>
                <item row="5" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_9">
+                <layout class="QHBoxLayout" name="layoutH_for_0_item_hints">
                  <item>
                   <widget class="QLabel" name="label_for_num_item_hints">
                    <property name="text">
@@ -1182,7 +1186,7 @@
                 </layout>
                </item>
                <item row="5" column="3">
-                <layout class="QHBoxLayout" name="horizontalLayout_15">
+                <layout class="QHBoxLayout" name="layoutH_for_3_path_hints">
                  <item>
                   <widget class="QLabel" name="label_for_num_path_hints">
                    <property name="text">
@@ -1215,7 +1219,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_6">
+             <widget class="QGroupBox" name="layoutG_for_3_advanced">
               <property name="title">
                <string>Additional Advanced Options</string>
               </property>
@@ -1244,7 +1248,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="verticalSpacer_3">
+             <spacer name="zzzz_spacerV_for_advanced">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
@@ -1289,7 +1293,7 @@
      </widget>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QHBoxLayout" name="layoutH_for_2_permalink">
       <item>
        <widget class="QLabel" name="label_for_permalink">
         <property name="text">
@@ -1313,7 +1317,7 @@
      </widget>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <layout class="QHBoxLayout" name="layoutH_for_4_buttons">
       <item>
        <widget class="QPushButton" name="about_button">
         <property name="text">
@@ -1322,7 +1326,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer">
+       <spacer name="zzzz_spacerH_for_about">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
@@ -1348,7 +1352,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer_2">
+       <spacer name="zzzz_spacerH_for_default">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
@@ -1381,7 +1385,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>scrollArea</tabstop>
+  <tabstop>layoutS_for_0_primary</tabstop>
   <tabstop>clean_iso_path</tabstop>
   <tabstop>clean_iso_path_browse_button</tabstop>
   <tabstop>output_folder</tabstop>

--- a/wwr_ui/uic/ui_cosmetic_tab.py
+++ b/wwr_ui/uic/ui_cosmetic_tab.py
@@ -26,79 +26,79 @@ class Ui_CosmeticTab(object):
         CosmeticTab.resize(864, 553)
         self.horizontalLayout_14 = QHBoxLayout(CosmeticTab)
         self.horizontalLayout_14.setObjectName(u"horizontalLayout_14")
-        self.verticalLayout_10 = QVBoxLayout()
-        self.verticalLayout_10.setObjectName(u"verticalLayout_10")
-        self.gridLayout_5 = QGridLayout()
-        self.gridLayout_5.setObjectName(u"gridLayout_5")
-        self.horizontalLayout_11 = QHBoxLayout()
-        self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
+        self.layoutV_for_0_cosmetic_options = QVBoxLayout()
+        self.layoutV_for_0_cosmetic_options.setObjectName(u"layoutV_for_0_cosmetic_options")
+        self.layoutG_for_0_model_settings = QGridLayout()
+        self.layoutG_for_0_model_settings.setObjectName(u"layoutG_for_0_model_settings")
+        self.layoutH_for_random_colors = QHBoxLayout()
+        self.layoutH_for_random_colors.setObjectName(u"layoutH_for_random_colors")
         self.randomize_all_custom_colors_together = QPushButton(CosmeticTab)
         self.randomize_all_custom_colors_together.setObjectName(u"randomize_all_custom_colors_together")
 
-        self.horizontalLayout_11.addWidget(self.randomize_all_custom_colors_together)
+        self.layoutH_for_random_colors.addWidget(self.randomize_all_custom_colors_together)
 
         self.randomize_all_custom_colors_separately = QPushButton(CosmeticTab)
         self.randomize_all_custom_colors_separately.setObjectName(u"randomize_all_custom_colors_separately")
 
-        self.horizontalLayout_11.addWidget(self.randomize_all_custom_colors_separately)
+        self.layoutH_for_random_colors.addWidget(self.randomize_all_custom_colors_separately)
 
 
-        self.gridLayout_5.addLayout(self.horizontalLayout_11, 2, 1, 1, 1)
+        self.layoutG_for_0_model_settings.addLayout(self.layoutH_for_random_colors, 2, 1, 1, 1)
 
-        self.horizontalLayout_10 = QHBoxLayout()
-        self.horizontalLayout_10.setObjectName(u"horizontalLayout_10")
+        self.layoutH_for_2_color_present = QHBoxLayout()
+        self.layoutH_for_2_color_present.setObjectName(u"layoutH_for_2_color_present")
         self.label_for_custom_color_preset = QLabel(CosmeticTab)
         self.label_for_custom_color_preset.setObjectName(u"label_for_custom_color_preset")
 
-        self.horizontalLayout_10.addWidget(self.label_for_custom_color_preset)
+        self.layoutH_for_2_color_present.addWidget(self.label_for_custom_color_preset)
 
         self.custom_color_preset = QComboBox(CosmeticTab)
         self.custom_color_preset.setObjectName(u"custom_color_preset")
 
-        self.horizontalLayout_10.addWidget(self.custom_color_preset)
+        self.layoutH_for_2_color_present.addWidget(self.custom_color_preset)
 
 
-        self.gridLayout_5.addLayout(self.horizontalLayout_10, 2, 0, 1, 1)
+        self.layoutG_for_0_model_settings.addLayout(self.layoutH_for_2_color_present, 2, 0, 1, 1)
 
-        self.horizontalLayout_12 = QHBoxLayout()
-        self.horizontalLayout_12.setObjectName(u"horizontalLayout_12")
+        self.layoutH_for_0_model = QHBoxLayout()
+        self.layoutH_for_0_model.setObjectName(u"layoutH_for_0_model")
         self.label_for_custom_player_model = QLabel(CosmeticTab)
         self.label_for_custom_player_model.setObjectName(u"label_for_custom_player_model")
 
-        self.horizontalLayout_12.addWidget(self.label_for_custom_player_model)
+        self.layoutH_for_0_model.addWidget(self.label_for_custom_player_model)
 
         self.custom_player_model = QComboBox(CosmeticTab)
         self.custom_player_model.setObjectName(u"custom_player_model")
 
-        self.horizontalLayout_12.addWidget(self.custom_player_model)
+        self.layoutH_for_0_model.addWidget(self.custom_player_model)
 
 
-        self.gridLayout_5.addLayout(self.horizontalLayout_12, 1, 0, 1, 1)
+        self.layoutG_for_0_model_settings.addLayout(self.layoutH_for_0_model, 1, 0, 1, 1)
 
-        self.horizontalLayout_13 = QHBoxLayout()
-        self.horizontalLayout_13.setObjectName(u"horizontalLayout_13")
+        self.layoutH_for_1_custom_options = QHBoxLayout()
+        self.layoutH_for_1_custom_options.setObjectName(u"layoutH_for_1_custom_options")
         self.player_in_casual_clothes = QCheckBox(CosmeticTab)
         self.player_in_casual_clothes.setObjectName(u"player_in_casual_clothes")
 
-        self.horizontalLayout_13.addWidget(self.player_in_casual_clothes)
+        self.layoutH_for_1_custom_options.addWidget(self.player_in_casual_clothes)
 
         self.disable_custom_player_voice = QCheckBox(CosmeticTab)
         self.disable_custom_player_voice.setObjectName(u"disable_custom_player_voice")
 
-        self.horizontalLayout_13.addWidget(self.disable_custom_player_voice)
+        self.layoutH_for_1_custom_options.addWidget(self.disable_custom_player_voice)
 
         self.disable_custom_player_items = QCheckBox(CosmeticTab)
         self.disable_custom_player_items.setObjectName(u"disable_custom_player_items")
 
-        self.horizontalLayout_13.addWidget(self.disable_custom_player_items)
+        self.layoutH_for_1_custom_options.addWidget(self.disable_custom_player_items)
 
 
-        self.gridLayout_5.addLayout(self.horizontalLayout_13, 1, 1, 1, 1)
+        self.layoutG_for_0_model_settings.addLayout(self.layoutH_for_1_custom_options, 1, 1, 1, 1)
 
         self.install_custom_model = QPushButton(CosmeticTab)
         self.install_custom_model.setObjectName(u"install_custom_model")
 
-        self.gridLayout_5.addWidget(self.install_custom_model, 0, 0, 1, 2)
+        self.layoutG_for_0_model_settings.addWidget(self.install_custom_model, 0, 0, 1, 2)
 
         self.custom_model_comment = QLabel(CosmeticTab)
         self.custom_model_comment.setObjectName(u"custom_model_comment")
@@ -106,40 +106,40 @@ class Ui_CosmeticTab(object):
         self.custom_model_comment.setTextFormat(Qt.PlainText)
         self.custom_model_comment.setWordWrap(True)
 
-        self.gridLayout_5.addWidget(self.custom_model_comment, 3, 0, 1, 2)
+        self.layoutG_for_0_model_settings.addWidget(self.custom_model_comment, 3, 0, 1, 2)
 
 
-        self.verticalLayout_10.addLayout(self.gridLayout_5)
+        self.layoutV_for_0_cosmetic_options.addLayout(self.layoutG_for_0_model_settings)
 
         self.custom_colors_layout = QVBoxLayout()
         self.custom_colors_layout.setObjectName(u"custom_colors_layout")
 
-        self.verticalLayout_10.addLayout(self.custom_colors_layout)
+        self.layoutV_for_0_cosmetic_options.addLayout(self.custom_colors_layout)
 
-        self.horizontalLayout_18 = QHBoxLayout()
-        self.horizontalLayout_18.setObjectName(u"horizontalLayout_18")
+        self.layoutH_for_1_present = QHBoxLayout()
+        self.layoutH_for_1_present.setObjectName(u"layoutH_for_1_present")
         self.save_custom_color_preset = QPushButton(CosmeticTab)
         self.save_custom_color_preset.setObjectName(u"save_custom_color_preset")
 
-        self.horizontalLayout_18.addWidget(self.save_custom_color_preset)
+        self.layoutH_for_1_present.addWidget(self.save_custom_color_preset)
 
         self.load_custom_color_preset = QPushButton(CosmeticTab)
         self.load_custom_color_preset.setObjectName(u"load_custom_color_preset")
 
-        self.horizontalLayout_18.addWidget(self.load_custom_color_preset)
+        self.layoutH_for_1_present.addWidget(self.load_custom_color_preset)
 
 
-        self.verticalLayout_10.addLayout(self.horizontalLayout_18)
+        self.layoutV_for_0_cosmetic_options.addLayout(self.layoutH_for_1_present)
 
-        self.verticalSpacer_4 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.zzzz_spacerV_for_cosmetic_options = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
-        self.verticalLayout_10.addItem(self.verticalSpacer_4)
+        self.layoutV_for_0_cosmetic_options.addItem(self.zzzz_spacerV_for_cosmetic_options)
 
 
-        self.horizontalLayout_14.addLayout(self.verticalLayout_10)
+        self.horizontalLayout_14.addLayout(self.layoutV_for_0_cosmetic_options)
 
-        self.verticalLayout_11 = QVBoxLayout()
-        self.verticalLayout_11.setObjectName(u"verticalLayout_11")
+        self.layoutV_for_1_preview = QVBoxLayout()
+        self.layoutV_for_1_preview.setObjectName(u"layoutV_for_1_preview")
         self.custom_model_preview_label = QLabel(CosmeticTab)
         self.custom_model_preview_label.setObjectName(u"custom_model_preview_label")
         sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
@@ -149,14 +149,14 @@ class Ui_CosmeticTab(object):
         self.custom_model_preview_label.setSizePolicy(sizePolicy)
         self.custom_model_preview_label.setMinimumSize(QSize(225, 350))
 
-        self.verticalLayout_11.addWidget(self.custom_model_preview_label)
+        self.layoutV_for_1_preview.addWidget(self.custom_model_preview_label)
 
-        self.verticalSpacer_5 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.zzzz_spacerV_for_preview = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
-        self.verticalLayout_11.addItem(self.verticalSpacer_5)
+        self.layoutV_for_1_preview.addItem(self.zzzz_spacerV_for_preview)
 
 
-        self.horizontalLayout_14.addLayout(self.verticalLayout_11)
+        self.horizontalLayout_14.addLayout(self.layoutV_for_1_preview)
 
 
         self.retranslateUi(CosmeticTab)

--- a/wwr_ui/uic/ui_randomizer_window.py
+++ b/wwr_ui/uic/ui_randomizer_window.py
@@ -33,175 +33,90 @@ class Ui_MainWindow(object):
         self.centralwidget.setObjectName(u"centralwidget")
         self.verticalLayout = QVBoxLayout(self.centralwidget)
         self.verticalLayout.setObjectName(u"verticalLayout")
-        self.scrollArea = QScrollArea(self.centralwidget)
-        self.scrollArea.setObjectName(u"scrollArea")
-        self.scrollArea.setMinimumSize(QSize(600, 400))
-        self.scrollArea.setFrameShape(QFrame.NoFrame)
-        self.scrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
-        self.scrollArea.setWidgetResizable(True)
-        self.scrollAreaWidgetContents = QWidget()
-        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
-        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 870, 582))
-        self.verticalLayout_2 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.layoutS_for_0_primary = QScrollArea(self.centralwidget)
+        self.layoutS_for_0_primary.setObjectName(u"layoutS_for_0_primary")
+        self.layoutS_for_0_primary.setMinimumSize(QSize(600, 400))
+        self.layoutS_for_0_primary.setFrameShape(QFrame.NoFrame)
+        self.layoutS_for_0_primary.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
+        self.layoutS_for_0_primary.setWidgetResizable(True)
+        self.scrollA_for_primary = QWidget()
+        self.scrollA_for_primary.setObjectName(u"scrollA_for_primary")
+        self.scrollA_for_primary.setGeometry(QRect(0, 0, 870, 608))
+        self.verticalLayout_2 = QVBoxLayout(self.scrollA_for_primary)
         self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
-        self.tabWidget = QTabWidget(self.scrollAreaWidgetContents)
-        self.tabWidget.setObjectName(u"tabWidget")
-        self.tabWidget.setEnabled(True)
+        self.tabs_for_primary = QTabWidget(self.scrollA_for_primary)
+        self.tabs_for_primary.setObjectName(u"tabs_for_primary")
+        self.tabs_for_primary.setEnabled(True)
         self.tab_randomizer_settings = QWidget()
         self.tab_randomizer_settings.setObjectName(u"tab_randomizer_settings")
         self.verticalLayout_3 = QVBoxLayout(self.tab_randomizer_settings)
         self.verticalLayout_3.setObjectName(u"verticalLayout_3")
-        self.gridLayout = QGridLayout()
-        self.gridLayout.setObjectName(u"gridLayout")
+        self.layoutG_for_0_paths = QGridLayout()
+        self.layoutG_for_0_paths.setObjectName(u"layoutG_for_0_paths")
         self.seed = QLineEdit(self.tab_randomizer_settings)
         self.seed.setObjectName(u"seed")
 
-        self.gridLayout.addWidget(self.seed, 2, 1, 1, 1)
+        self.layoutG_for_0_paths.addWidget(self.seed, 2, 1, 1, 1)
 
         self.label_for_clean_iso_path = QLabel(self.tab_randomizer_settings)
         self.label_for_clean_iso_path.setObjectName(u"label_for_clean_iso_path")
         self.label_for_clean_iso_path.setTextFormat(Qt.MarkdownText)
 
-        self.gridLayout.addWidget(self.label_for_clean_iso_path, 0, 0, 1, 1)
+        self.layoutG_for_0_paths.addWidget(self.label_for_clean_iso_path, 0, 0, 1, 1)
 
         self.clean_iso_path = QLineEdit(self.tab_randomizer_settings)
         self.clean_iso_path.setObjectName(u"clean_iso_path")
 
-        self.gridLayout.addWidget(self.clean_iso_path, 0, 1, 1, 1)
+        self.layoutG_for_0_paths.addWidget(self.clean_iso_path, 0, 1, 1, 1)
 
         self.label_for_output_folder = QLabel(self.tab_randomizer_settings)
         self.label_for_output_folder.setObjectName(u"label_for_output_folder")
 
-        self.gridLayout.addWidget(self.label_for_output_folder, 1, 0, 1, 1)
+        self.layoutG_for_0_paths.addWidget(self.label_for_output_folder, 1, 0, 1, 1)
 
         self.output_folder = QLineEdit(self.tab_randomizer_settings)
         self.output_folder.setObjectName(u"output_folder")
 
-        self.gridLayout.addWidget(self.output_folder, 1, 1, 1, 1)
+        self.layoutG_for_0_paths.addWidget(self.output_folder, 1, 1, 1, 1)
 
         self.output_folder_browse_button = QPushButton(self.tab_randomizer_settings)
         self.output_folder_browse_button.setObjectName(u"output_folder_browse_button")
 
-        self.gridLayout.addWidget(self.output_folder_browse_button, 1, 2, 1, 1)
+        self.layoutG_for_0_paths.addWidget(self.output_folder_browse_button, 1, 2, 1, 1)
 
         self.label_for_seed = QLabel(self.tab_randomizer_settings)
         self.label_for_seed.setObjectName(u"label_for_seed")
 
-        self.gridLayout.addWidget(self.label_for_seed, 2, 0, 1, 1)
+        self.layoutG_for_0_paths.addWidget(self.label_for_seed, 2, 0, 1, 1)
 
         self.generate_seed_button = QPushButton(self.tab_randomizer_settings)
         self.generate_seed_button.setObjectName(u"generate_seed_button")
 
-        self.gridLayout.addWidget(self.generate_seed_button, 2, 2, 1, 1)
+        self.layoutG_for_0_paths.addWidget(self.generate_seed_button, 2, 2, 1, 1)
 
         self.clean_iso_path_browse_button = QPushButton(self.tab_randomizer_settings)
         self.clean_iso_path_browse_button.setObjectName(u"clean_iso_path_browse_button")
 
-        self.gridLayout.addWidget(self.clean_iso_path_browse_button, 0, 2, 1, 1)
+        self.layoutG_for_0_paths.addWidget(self.clean_iso_path_browse_button, 0, 2, 1, 1)
 
 
-        self.verticalLayout_3.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.layoutG_for_0_paths)
 
         self.progression_locations_groupbox = QGroupBox(self.tab_randomizer_settings)
         self.progression_locations_groupbox.setObjectName(u"progression_locations_groupbox")
         self.gridLayout_2 = QGridLayout(self.progression_locations_groupbox)
         self.gridLayout_2.setObjectName(u"gridLayout_2")
-        self.progression_platforms_rafts = QCheckBox(self.progression_locations_groupbox)
-        self.progression_platforms_rafts.setObjectName(u"progression_platforms_rafts")
-
-        self.gridLayout_2.addWidget(self.progression_platforms_rafts, 1, 4, 1, 1)
-
-        self.progression_expensive_purchases = QCheckBox(self.progression_locations_groupbox)
-        self.progression_expensive_purchases.setObjectName(u"progression_expensive_purchases")
-        self.progression_expensive_purchases.setChecked(True)
-
-        self.gridLayout_2.addWidget(self.progression_expensive_purchases, 6, 0, 1, 1)
-
-        self.progression_dungeon_secrets = QCheckBox(self.progression_locations_groupbox)
-        self.progression_dungeon_secrets.setObjectName(u"progression_dungeon_secrets")
-
-        self.gridLayout_2.addWidget(self.progression_dungeon_secrets, 1, 0, 1, 1)
-
-        self.progression_treasure_charts = QCheckBox(self.progression_locations_groupbox)
-        self.progression_treasure_charts.setObjectName(u"progression_treasure_charts")
-
-        self.gridLayout_2.addWidget(self.progression_treasure_charts, 6, 3, 1, 2)
-
-        self.progression_tingle_chests = QCheckBox(self.progression_locations_groupbox)
-        self.progression_tingle_chests.setObjectName(u"progression_tingle_chests")
-
-        self.gridLayout_2.addWidget(self.progression_tingle_chests, 1, 1, 1, 1)
-
-        self.progression_savage_labyrinth = QCheckBox(self.progression_locations_groupbox)
-        self.progression_savage_labyrinth.setObjectName(u"progression_savage_labyrinth")
-
-        self.gridLayout_2.addWidget(self.progression_savage_labyrinth, 0, 3, 1, 1)
-
         self.progression_dungeons = QCheckBox(self.progression_locations_groupbox)
         self.progression_dungeons.setObjectName(u"progression_dungeons")
         self.progression_dungeons.setChecked(True)
 
         self.gridLayout_2.addWidget(self.progression_dungeons, 0, 0, 1, 1)
 
-        self.progression_triforce_charts = QCheckBox(self.progression_locations_groupbox)
-        self.progression_triforce_charts.setObjectName(u"progression_triforce_charts")
+        self.progression_tingle_chests = QCheckBox(self.progression_locations_groupbox)
+        self.progression_tingle_chests.setObjectName(u"progression_tingle_chests")
 
-        self.gridLayout_2.addWidget(self.progression_triforce_charts, 6, 1, 1, 2)
-
-        self.progression_combat_secret_caves = QCheckBox(self.progression_locations_groupbox)
-        self.progression_combat_secret_caves.setObjectName(u"progression_combat_secret_caves")
-
-        self.gridLayout_2.addWidget(self.progression_combat_secret_caves, 0, 2, 1, 1)
-
-        self.progression_big_octos_gunboats = QCheckBox(self.progression_locations_groupbox)
-        self.progression_big_octos_gunboats.setObjectName(u"progression_big_octos_gunboats")
-
-        self.gridLayout_2.addWidget(self.progression_big_octos_gunboats, 4, 4, 1, 1)
-
-        self.progression_island_puzzles = QCheckBox(self.progression_locations_groupbox)
-        self.progression_island_puzzles.setObjectName(u"progression_island_puzzles")
-
-        self.gridLayout_2.addWidget(self.progression_island_puzzles, 0, 4, 1, 1)
-
-        self.progression_great_fairies = QCheckBox(self.progression_locations_groupbox)
-        self.progression_great_fairies.setObjectName(u"progression_great_fairies")
-        self.progression_great_fairies.setChecked(True)
-
-        self.gridLayout_2.addWidget(self.progression_great_fairies, 1, 2, 1, 1)
-
-        self.progression_puzzle_secret_caves = QCheckBox(self.progression_locations_groupbox)
-        self.progression_puzzle_secret_caves.setObjectName(u"progression_puzzle_secret_caves")
-        self.progression_puzzle_secret_caves.setChecked(True)
-
-        self.gridLayout_2.addWidget(self.progression_puzzle_secret_caves, 0, 1, 1, 1)
-
-        self.progression_battlesquid = QCheckBox(self.progression_locations_groupbox)
-        self.progression_battlesquid.setObjectName(u"progression_battlesquid")
-
-        self.gridLayout_2.addWidget(self.progression_battlesquid, 5, 2, 1, 1)
-
-        self.progression_minigames = QCheckBox(self.progression_locations_groupbox)
-        self.progression_minigames.setObjectName(u"progression_minigames")
-
-        self.gridLayout_2.addWidget(self.progression_minigames, 5, 1, 1, 1)
-
-        self.progression_misc = QCheckBox(self.progression_locations_groupbox)
-        self.progression_misc.setObjectName(u"progression_misc")
-        self.progression_misc.setChecked(True)
-
-        self.gridLayout_2.addWidget(self.progression_misc, 5, 0, 1, 1)
-
-        self.progression_submarines = QCheckBox(self.progression_locations_groupbox)
-        self.progression_submarines.setObjectName(u"progression_submarines")
-        self.progression_submarines.setChecked(False)
-
-        self.gridLayout_2.addWidget(self.progression_submarines, 1, 3, 1, 1)
-
-        self.progression_short_sidequests = QCheckBox(self.progression_locations_groupbox)
-        self.progression_short_sidequests.setObjectName(u"progression_short_sidequests")
-
-        self.gridLayout_2.addWidget(self.progression_short_sidequests, 4, 0, 1, 1)
+        self.gridLayout_2.addWidget(self.progression_tingle_chests, 0, 1, 1, 1)
 
         self.progression_long_sidequests = QCheckBox(self.progression_locations_groupbox)
         self.progression_long_sidequests.setObjectName(u"progression_long_sidequests")
@@ -213,37 +128,127 @@ class Ui_MainWindow(object):
 
         self.gridLayout_2.addWidget(self.progression_spoils_trading, 4, 2, 1, 1)
 
-        self.progression_eye_reef_chests = QCheckBox(self.progression_locations_groupbox)
-        self.progression_eye_reef_chests.setObjectName(u"progression_eye_reef_chests")
+        self.progression_short_sidequests = QCheckBox(self.progression_locations_groupbox)
+        self.progression_short_sidequests.setObjectName(u"progression_short_sidequests")
 
-        self.gridLayout_2.addWidget(self.progression_eye_reef_chests, 4, 3, 1, 1)
+        self.gridLayout_2.addWidget(self.progression_short_sidequests, 4, 0, 1, 1)
+
+        self.progression_puzzle_secret_caves = QCheckBox(self.progression_locations_groupbox)
+        self.progression_puzzle_secret_caves.setObjectName(u"progression_puzzle_secret_caves")
+        self.progression_puzzle_secret_caves.setChecked(True)
+
+        self.gridLayout_2.addWidget(self.progression_puzzle_secret_caves, 1, 0, 1, 1)
+
+        self.progression_savage_labyrinth = QCheckBox(self.progression_locations_groupbox)
+        self.progression_savage_labyrinth.setObjectName(u"progression_savage_labyrinth")
+
+        self.gridLayout_2.addWidget(self.progression_savage_labyrinth, 1, 2, 1, 1)
+
+        self.progression_combat_secret_caves = QCheckBox(self.progression_locations_groupbox)
+        self.progression_combat_secret_caves.setObjectName(u"progression_combat_secret_caves")
+
+        self.gridLayout_2.addWidget(self.progression_combat_secret_caves, 1, 1, 1, 1)
+
+        self.progression_dungeon_secrets = QCheckBox(self.progression_locations_groupbox)
+        self.progression_dungeon_secrets.setObjectName(u"progression_dungeon_secrets")
+
+        self.gridLayout_2.addWidget(self.progression_dungeon_secrets, 0, 2, 1, 1)
+
+        self.progression_battlesquid = QCheckBox(self.progression_locations_groupbox)
+        self.progression_battlesquid.setObjectName(u"progression_battlesquid")
+
+        self.gridLayout_2.addWidget(self.progression_battlesquid, 2, 3, 1, 1)
+
+        self.progression_mail = QCheckBox(self.progression_locations_groupbox)
+        self.progression_mail.setObjectName(u"progression_mail")
+
+        self.gridLayout_2.addWidget(self.progression_mail, 2, 1, 1, 1)
+
+        self.progression_great_fairies = QCheckBox(self.progression_locations_groupbox)
+        self.progression_great_fairies.setObjectName(u"progression_great_fairies")
+        self.progression_great_fairies.setChecked(True)
+
+        self.gridLayout_2.addWidget(self.progression_great_fairies, 1, 3, 1, 1)
+
+        self.z_layoutH_for_z_bottom = QHBoxLayout()
+        self.z_layoutH_for_z_bottom.setObjectName(u"z_layoutH_for_z_bottom")
+        self.progression_misc = QCheckBox(self.progression_locations_groupbox)
+        self.progression_misc.setObjectName(u"progression_misc")
+        self.progression_misc.setChecked(True)
+
+        self.z_layoutH_for_z_bottom.addWidget(self.progression_misc)
+
+        self.progression_treasure_charts = QCheckBox(self.progression_locations_groupbox)
+        self.progression_treasure_charts.setObjectName(u"progression_treasure_charts")
+
+        self.z_layoutH_for_z_bottom.addWidget(self.progression_treasure_charts)
+
+        self.progression_triforce_charts = QCheckBox(self.progression_locations_groupbox)
+        self.progression_triforce_charts.setObjectName(u"progression_triforce_charts")
+
+        self.z_layoutH_for_z_bottom.addWidget(self.progression_triforce_charts)
+
+
+        self.gridLayout_2.addLayout(self.z_layoutH_for_z_bottom, 7, 0, 1, 4)
+
+        self.progression_expensive_purchases = QCheckBox(self.progression_locations_groupbox)
+        self.progression_expensive_purchases.setObjectName(u"progression_expensive_purchases")
+        self.progression_expensive_purchases.setChecked(True)
+
+        self.gridLayout_2.addWidget(self.progression_expensive_purchases, 4, 3, 1, 1)
+
+        self.progression_minigames = QCheckBox(self.progression_locations_groupbox)
+        self.progression_minigames.setObjectName(u"progression_minigames")
+
+        self.gridLayout_2.addWidget(self.progression_minigames, 2, 2, 1, 1)
+
+        self.progression_submarines = QCheckBox(self.progression_locations_groupbox)
+        self.progression_submarines.setObjectName(u"progression_submarines")
+        self.progression_submarines.setChecked(False)
+
+        self.gridLayout_2.addWidget(self.progression_submarines, 5, 0, 1, 1)
+
+        self.progression_big_octos_gunboats = QCheckBox(self.progression_locations_groupbox)
+        self.progression_big_octos_gunboats.setObjectName(u"progression_big_octos_gunboats")
+
+        self.gridLayout_2.addWidget(self.progression_big_octos_gunboats, 5, 1, 1, 1)
+
+        self.progression_platforms_rafts = QCheckBox(self.progression_locations_groupbox)
+        self.progression_platforms_rafts.setObjectName(u"progression_platforms_rafts")
+
+        self.gridLayout_2.addWidget(self.progression_platforms_rafts, 5, 2, 1, 1)
 
         self.progression_free_gifts = QCheckBox(self.progression_locations_groupbox)
         self.progression_free_gifts.setObjectName(u"progression_free_gifts")
         self.progression_free_gifts.setChecked(True)
 
-        self.gridLayout_2.addWidget(self.progression_free_gifts, 5, 3, 1, 1)
+        self.gridLayout_2.addWidget(self.progression_free_gifts, 0, 3, 1, 1)
 
-        self.progression_mail = QCheckBox(self.progression_locations_groupbox)
-        self.progression_mail.setObjectName(u"progression_mail")
+        self.progression_island_puzzles = QCheckBox(self.progression_locations_groupbox)
+        self.progression_island_puzzles.setObjectName(u"progression_island_puzzles")
 
-        self.gridLayout_2.addWidget(self.progression_mail, 5, 4, 1, 1)
+        self.gridLayout_2.addWidget(self.progression_island_puzzles, 2, 0, 1, 1)
+
+        self.progression_eye_reef_chests = QCheckBox(self.progression_locations_groupbox)
+        self.progression_eye_reef_chests.setObjectName(u"progression_eye_reef_chests")
+
+        self.gridLayout_2.addWidget(self.progression_eye_reef_chests, 5, 3, 1, 1)
 
 
         self.verticalLayout_3.addWidget(self.progression_locations_groupbox)
 
-        self.groupBox_2 = QGroupBox(self.tab_randomizer_settings)
-        self.groupBox_2.setObjectName(u"groupBox_2")
-        self.gridLayout_3 = QGridLayout(self.groupBox_2)
+        self.layoutG_for_2_item_randomizers = QGroupBox(self.tab_randomizer_settings)
+        self.layoutG_for_2_item_randomizers.setObjectName(u"layoutG_for_2_item_randomizers")
+        self.gridLayout_3 = QGridLayout(self.layoutG_for_2_item_randomizers)
         self.gridLayout_3.setObjectName(u"gridLayout_3")
-        self.horizontalLayout_3 = QHBoxLayout()
-        self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
-        self.label_for_sword_mode = QLabel(self.groupBox_2)
+        self.layoutH_for_0_sword_mode = QHBoxLayout()
+        self.layoutH_for_0_sword_mode.setObjectName(u"layoutH_for_0_sword_mode")
+        self.label_for_sword_mode = QLabel(self.layoutG_for_2_item_randomizers)
         self.label_for_sword_mode.setObjectName(u"label_for_sword_mode")
 
-        self.horizontalLayout_3.addWidget(self.label_for_sword_mode)
+        self.layoutH_for_0_sword_mode.addWidget(self.label_for_sword_mode)
 
-        self.sword_mode = QComboBox(self.groupBox_2)
+        self.sword_mode = QComboBox(self.layoutG_for_2_item_randomizers)
         self.sword_mode.addItem("")
         self.sword_mode.addItem("")
         self.sword_mode.addItem("")
@@ -254,14 +259,14 @@ class Ui_MainWindow(object):
         sizePolicy.setHeightForWidth(self.sword_mode.sizePolicy().hasHeightForWidth())
         self.sword_mode.setSizePolicy(sizePolicy)
 
-        self.horizontalLayout_3.addWidget(self.sword_mode)
+        self.layoutH_for_0_sword_mode.addWidget(self.sword_mode)
 
 
-        self.gridLayout_3.addLayout(self.horizontalLayout_3, 0, 0, 1, 1)
+        self.gridLayout_3.addLayout(self.layoutH_for_0_sword_mode, 0, 0, 1, 1)
 
-        self.horizontalLayout_4 = QHBoxLayout()
-        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
-        self.label_for_num_starting_triforce_shards = QLabel(self.groupBox_2)
+        self.layoutH_for_1_triforce_shards = QHBoxLayout()
+        self.layoutH_for_1_triforce_shards.setObjectName(u"layoutH_for_1_triforce_shards")
+        self.label_for_num_starting_triforce_shards = QLabel(self.layoutG_for_2_item_randomizers)
         self.label_for_num_starting_triforce_shards.setObjectName(u"label_for_num_starting_triforce_shards")
         sizePolicy1 = QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Preferred)
         sizePolicy1.setHorizontalStretch(0)
@@ -269,9 +274,9 @@ class Ui_MainWindow(object):
         sizePolicy1.setHeightForWidth(self.label_for_num_starting_triforce_shards.sizePolicy().hasHeightForWidth())
         self.label_for_num_starting_triforce_shards.setSizePolicy(sizePolicy1)
 
-        self.horizontalLayout_4.addWidget(self.label_for_num_starting_triforce_shards)
+        self.layoutH_for_1_triforce_shards.addWidget(self.label_for_num_starting_triforce_shards)
 
-        self.num_starting_triforce_shards = QComboBox(self.groupBox_2)
+        self.num_starting_triforce_shards = QComboBox(self.layoutG_for_2_item_randomizers)
         self.num_starting_triforce_shards.addItem("")
         self.num_starting_triforce_shards.addItem("")
         self.num_starting_triforce_shards.addItem("")
@@ -287,259 +292,259 @@ class Ui_MainWindow(object):
         self.num_starting_triforce_shards.setMinimumSize(QSize(30, 0))
         self.num_starting_triforce_shards.setMaximumSize(QSize(40, 16777215))
 
-        self.horizontalLayout_4.addWidget(self.num_starting_triforce_shards)
+        self.layoutH_for_1_triforce_shards.addWidget(self.num_starting_triforce_shards)
 
-        self.widget = QWidget(self.groupBox_2)
+        self.widget = QWidget(self.layoutG_for_2_item_randomizers)
         self.widget.setObjectName(u"widget")
 
-        self.horizontalLayout_4.addWidget(self.widget)
+        self.layoutH_for_1_triforce_shards.addWidget(self.widget)
 
 
-        self.gridLayout_3.addLayout(self.horizontalLayout_4, 0, 1, 1, 1)
+        self.gridLayout_3.addLayout(self.layoutH_for_1_triforce_shards, 0, 1, 1, 1)
 
-        self.chest_type_matches_contents = QCheckBox(self.groupBox_2)
+        self.chest_type_matches_contents = QCheckBox(self.layoutG_for_2_item_randomizers)
         self.chest_type_matches_contents.setObjectName(u"chest_type_matches_contents")
 
         self.gridLayout_3.addWidget(self.chest_type_matches_contents, 0, 3, 1, 1)
 
-        self.keylunacy = QCheckBox(self.groupBox_2)
+        self.keylunacy = QCheckBox(self.layoutG_for_2_item_randomizers)
         self.keylunacy.setObjectName(u"keylunacy")
 
         self.gridLayout_3.addWidget(self.keylunacy, 0, 2, 1, 1)
 
 
-        self.verticalLayout_3.addWidget(self.groupBox_2)
+        self.verticalLayout_3.addWidget(self.layoutG_for_2_item_randomizers)
 
-        self.horizontalLayout_19 = QHBoxLayout()
-        self.horizontalLayout_19.setObjectName(u"horizontalLayout_19")
-        self.groupBox_7 = QGroupBox(self.tab_randomizer_settings)
-        self.groupBox_7.setObjectName(u"groupBox_7")
-        self.gridLayout_9 = QGridLayout(self.groupBox_7)
+        self.layoutH_for_3_randomizers = QHBoxLayout()
+        self.layoutH_for_3_randomizers.setObjectName(u"layoutH_for_3_randomizers")
+        self.layoutG_for_0_entrance = QGroupBox(self.tab_randomizer_settings)
+        self.layoutG_for_0_entrance.setObjectName(u"layoutG_for_0_entrance")
+        self.gridLayout_9 = QGridLayout(self.layoutG_for_0_entrance)
         self.gridLayout_9.setObjectName(u"gridLayout_9")
-        self.randomize_miniboss_entrances = QCheckBox(self.groupBox_7)
-        self.randomize_miniboss_entrances.setObjectName(u"randomize_miniboss_entrances")
-
-        self.gridLayout_9.addWidget(self.randomize_miniboss_entrances, 0, 2, 1, 1)
-
-        self.randomize_dungeon_entrances = QCheckBox(self.groupBox_7)
-        self.randomize_dungeon_entrances.setObjectName(u"randomize_dungeon_entrances")
-
-        self.gridLayout_9.addWidget(self.randomize_dungeon_entrances, 0, 0, 1, 1)
-
-        self.randomize_secret_cave_entrances = QCheckBox(self.groupBox_7)
-        self.randomize_secret_cave_entrances.setObjectName(u"randomize_secret_cave_entrances")
-
-        self.gridLayout_9.addWidget(self.randomize_secret_cave_entrances, 1, 0, 1, 1)
-
-        self.randomize_boss_entrances = QCheckBox(self.groupBox_7)
+        self.randomize_boss_entrances = QCheckBox(self.layoutG_for_0_entrance)
         self.randomize_boss_entrances.setObjectName(u"randomize_boss_entrances")
 
         self.gridLayout_9.addWidget(self.randomize_boss_entrances, 0, 1, 1, 1)
 
-        self.randomize_secret_cave_inner_entrances = QCheckBox(self.groupBox_7)
-        self.randomize_secret_cave_inner_entrances.setObjectName(u"randomize_secret_cave_inner_entrances")
-
-        self.gridLayout_9.addWidget(self.randomize_secret_cave_inner_entrances, 1, 1, 1, 1)
-
-        self.randomize_fairy_fountain_entrances = QCheckBox(self.groupBox_7)
+        self.randomize_fairy_fountain_entrances = QCheckBox(self.layoutG_for_0_entrance)
         self.randomize_fairy_fountain_entrances.setObjectName(u"randomize_fairy_fountain_entrances")
 
         self.gridLayout_9.addWidget(self.randomize_fairy_fountain_entrances, 1, 2, 1, 1)
 
-        self.horizontalLayout_5 = QHBoxLayout()
-        self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
-        self.label_for_mix_entrances = QLabel(self.groupBox_7)
+        self.randomize_secret_cave_inner_entrances = QCheckBox(self.layoutG_for_0_entrance)
+        self.randomize_secret_cave_inner_entrances.setObjectName(u"randomize_secret_cave_inner_entrances")
+
+        self.gridLayout_9.addWidget(self.randomize_secret_cave_inner_entrances, 1, 1, 1, 1)
+
+        self.randomize_secret_cave_entrances = QCheckBox(self.layoutG_for_0_entrance)
+        self.randomize_secret_cave_entrances.setObjectName(u"randomize_secret_cave_entrances")
+
+        self.gridLayout_9.addWidget(self.randomize_secret_cave_entrances, 1, 0, 1, 1)
+
+        self.randomize_dungeon_entrances = QCheckBox(self.layoutG_for_0_entrance)
+        self.randomize_dungeon_entrances.setObjectName(u"randomize_dungeon_entrances")
+
+        self.gridLayout_9.addWidget(self.randomize_dungeon_entrances, 0, 0, 1, 1)
+
+        self.randomize_miniboss_entrances = QCheckBox(self.layoutG_for_0_entrance)
+        self.randomize_miniboss_entrances.setObjectName(u"randomize_miniboss_entrances")
+
+        self.gridLayout_9.addWidget(self.randomize_miniboss_entrances, 0, 2, 1, 1)
+
+        self.layoutH_for_0_mix = QHBoxLayout()
+        self.layoutH_for_0_mix.setObjectName(u"layoutH_for_0_mix")
+        self.label_for_mix_entrances = QLabel(self.layoutG_for_0_entrance)
         self.label_for_mix_entrances.setObjectName(u"label_for_mix_entrances")
 
-        self.horizontalLayout_5.addWidget(self.label_for_mix_entrances)
+        self.layoutH_for_0_mix.addWidget(self.label_for_mix_entrances)
 
-        self.mix_entrances = QComboBox(self.groupBox_7)
+        self.mix_entrances = QComboBox(self.layoutG_for_0_entrance)
         self.mix_entrances.addItem("")
         self.mix_entrances.addItem("")
         self.mix_entrances.setObjectName(u"mix_entrances")
         sizePolicy.setHeightForWidth(self.mix_entrances.sizePolicy().hasHeightForWidth())
         self.mix_entrances.setSizePolicy(sizePolicy)
 
-        self.horizontalLayout_5.addWidget(self.mix_entrances)
+        self.layoutH_for_0_mix.addWidget(self.mix_entrances)
 
 
-        self.gridLayout_9.addLayout(self.horizontalLayout_5, 2, 0, 1, 3)
+        self.gridLayout_9.addLayout(self.layoutH_for_0_mix, 2, 0, 1, 3)
 
 
-        self.horizontalLayout_19.addWidget(self.groupBox_7)
+        self.layoutH_for_3_randomizers.addWidget(self.layoutG_for_0_entrance)
 
-        self.groupBox_8 = QGroupBox(self.tab_randomizer_settings)
-        self.groupBox_8.setObjectName(u"groupBox_8")
-        self.gridLayout_10 = QGridLayout(self.groupBox_8)
+        self.layoutG_for_1_other = QGroupBox(self.tab_randomizer_settings)
+        self.layoutG_for_1_other.setObjectName(u"layoutG_for_1_other")
+        self.gridLayout_10 = QGridLayout(self.layoutG_for_1_other)
         self.gridLayout_10.setObjectName(u"gridLayout_10")
-        self.randomize_enemies = QCheckBox(self.groupBox_8)
+        self.randomize_enemies = QCheckBox(self.layoutG_for_1_other)
         self.randomize_enemies.setObjectName(u"randomize_enemies")
 
         self.gridLayout_10.addWidget(self.randomize_enemies, 1, 1, 1, 1)
 
-        self.randomize_charts = QCheckBox(self.groupBox_8)
+        self.randomize_charts = QCheckBox(self.layoutG_for_1_other)
         self.randomize_charts.setObjectName(u"randomize_charts")
 
         self.gridLayout_10.addWidget(self.randomize_charts, 0, 1, 1, 1)
 
-        self.randomize_enemy_palettes = QCheckBox(self.groupBox_8)
+        self.randomize_enemy_palettes = QCheckBox(self.layoutG_for_1_other)
         self.randomize_enemy_palettes.setObjectName(u"randomize_enemy_palettes")
 
         self.gridLayout_10.addWidget(self.randomize_enemy_palettes, 1, 0, 1, 1)
 
-        self.randomize_starting_island = QCheckBox(self.groupBox_8)
+        self.randomize_starting_island = QCheckBox(self.layoutG_for_1_other)
         self.randomize_starting_island.setObjectName(u"randomize_starting_island")
 
         self.gridLayout_10.addWidget(self.randomize_starting_island, 0, 0, 1, 1)
 
-        self.widget_2 = QWidget(self.groupBox_8)
+        self.widget_2 = QWidget(self.layoutG_for_1_other)
         self.widget_2.setObjectName(u"widget_2")
 
         self.gridLayout_10.addWidget(self.widget_2, 2, 0, 1, 1)
 
 
-        self.horizontalLayout_19.addWidget(self.groupBox_8)
+        self.layoutH_for_3_randomizers.addWidget(self.layoutG_for_1_other)
 
 
-        self.verticalLayout_3.addLayout(self.horizontalLayout_19)
+        self.verticalLayout_3.addLayout(self.layoutH_for_3_randomizers)
 
-        self.groupBox_3 = QGroupBox(self.tab_randomizer_settings)
-        self.groupBox_3.setObjectName(u"groupBox_3")
-        self.gridLayout_4 = QGridLayout(self.groupBox_3)
+        self.layoutG_for_4_convenience = QGroupBox(self.tab_randomizer_settings)
+        self.layoutG_for_4_convenience.setObjectName(u"layoutG_for_4_convenience")
+        self.gridLayout_4 = QGridLayout(self.layoutG_for_4_convenience)
         self.gridLayout_4.setObjectName(u"gridLayout_4")
-        self.invert_sea_compass_x_axis = QCheckBox(self.groupBox_3)
+        self.invert_sea_compass_x_axis = QCheckBox(self.layoutG_for_4_convenience)
         self.invert_sea_compass_x_axis.setObjectName(u"invert_sea_compass_x_axis")
 
         self.gridLayout_4.addWidget(self.invert_sea_compass_x_axis, 0, 4, 1, 1)
 
-        self.invert_camera_x_axis = QCheckBox(self.groupBox_3)
+        self.invert_camera_x_axis = QCheckBox(self.layoutG_for_4_convenience)
         self.invert_camera_x_axis.setObjectName(u"invert_camera_x_axis")
 
         self.gridLayout_4.addWidget(self.invert_camera_x_axis, 1, 4, 1, 1)
 
-        self.instant_text_boxes = QCheckBox(self.groupBox_3)
+        self.instant_text_boxes = QCheckBox(self.layoutG_for_4_convenience)
         self.instant_text_boxes.setObjectName(u"instant_text_boxes")
         self.instant_text_boxes.setChecked(True)
 
         self.gridLayout_4.addWidget(self.instant_text_boxes, 0, 1, 1, 1)
 
-        self.reveal_full_sea_chart = QCheckBox(self.groupBox_3)
+        self.reveal_full_sea_chart = QCheckBox(self.layoutG_for_4_convenience)
         self.reveal_full_sea_chart.setObjectName(u"reveal_full_sea_chart")
         self.reveal_full_sea_chart.setChecked(True)
 
         self.gridLayout_4.addWidget(self.reveal_full_sea_chart, 0, 3, 1, 1)
 
-        self.swift_sail = QCheckBox(self.groupBox_3)
+        self.swift_sail = QCheckBox(self.layoutG_for_4_convenience)
         self.swift_sail.setObjectName(u"swift_sail")
         self.swift_sail.setChecked(True)
 
         self.gridLayout_4.addWidget(self.swift_sail, 0, 0, 1, 1)
 
-        self.remove_title_and_ending_videos = QCheckBox(self.groupBox_3)
+        self.remove_title_and_ending_videos = QCheckBox(self.layoutG_for_4_convenience)
         self.remove_title_and_ending_videos.setObjectName(u"remove_title_and_ending_videos")
         self.remove_title_and_ending_videos.setChecked(True)
 
         self.gridLayout_4.addWidget(self.remove_title_and_ending_videos, 1, 3, 1, 1)
 
-        self.skip_rematch_bosses = QCheckBox(self.groupBox_3)
+        self.skip_rematch_bosses = QCheckBox(self.layoutG_for_4_convenience)
         self.skip_rematch_bosses.setObjectName(u"skip_rematch_bosses")
         self.skip_rematch_bosses.setChecked(True)
 
         self.gridLayout_4.addWidget(self.skip_rematch_bosses, 1, 0, 1, 1)
 
-        self.remove_music = QCheckBox(self.groupBox_3)
+        self.remove_music = QCheckBox(self.layoutG_for_4_convenience)
         self.remove_music.setObjectName(u"remove_music")
 
         self.gridLayout_4.addWidget(self.remove_music, 0, 2, 1, 1)
 
-        self.add_shortcut_warps_between_dungeons = QCheckBox(self.groupBox_3)
+        self.add_shortcut_warps_between_dungeons = QCheckBox(self.layoutG_for_4_convenience)
         self.add_shortcut_warps_between_dungeons.setObjectName(u"add_shortcut_warps_between_dungeons")
 
         self.gridLayout_4.addWidget(self.add_shortcut_warps_between_dungeons, 1, 1, 1, 2)
 
 
-        self.verticalLayout_3.addWidget(self.groupBox_3)
+        self.verticalLayout_3.addWidget(self.layoutG_for_4_convenience)
 
-        self.verticalSpacer_7 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.zzzz_spacerV_for_randomizer_settings = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
-        self.verticalLayout_3.addItem(self.verticalSpacer_7)
+        self.verticalLayout_3.addItem(self.zzzz_spacerV_for_randomizer_settings)
 
-        self.tabWidget.addTab(self.tab_randomizer_settings, "")
+        self.tabs_for_primary.addTab(self.tab_randomizer_settings, "")
         self.tab_starting_items = QWidget()
         self.tab_starting_items.setObjectName(u"tab_starting_items")
         self.tab_starting_items.setEnabled(True)
         self.verticalLayout_4 = QVBoxLayout(self.tab_starting_items)
         self.verticalLayout_4.setObjectName(u"verticalLayout_4")
-        self.horizontalLayout_6 = QHBoxLayout()
-        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
-        self.verticalLayout_5 = QVBoxLayout()
-        self.verticalLayout_5.setObjectName(u"verticalLayout_5")
+        self.layoutH_for_0_gear = QHBoxLayout()
+        self.layoutH_for_0_gear.setObjectName(u"layoutH_for_0_gear")
+        self.layoutV_for_0_randomized_gear = QVBoxLayout()
+        self.layoutV_for_0_randomized_gear.setObjectName(u"layoutV_for_0_randomized_gear")
         self.label_for_randomized_gear = QLabel(self.tab_starting_items)
         self.label_for_randomized_gear.setObjectName(u"label_for_randomized_gear")
 
-        self.verticalLayout_5.addWidget(self.label_for_randomized_gear)
+        self.layoutV_for_0_randomized_gear.addWidget(self.label_for_randomized_gear)
 
         self.randomized_gear = QListView(self.tab_starting_items)
         self.randomized_gear.setObjectName(u"randomized_gear")
         self.randomized_gear.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.randomized_gear.setSelectionMode(QAbstractItemView.ExtendedSelection)
 
-        self.verticalLayout_5.addWidget(self.randomized_gear)
+        self.layoutV_for_0_randomized_gear.addWidget(self.randomized_gear)
 
 
-        self.horizontalLayout_6.addLayout(self.verticalLayout_5)
+        self.layoutH_for_0_gear.addLayout(self.layoutV_for_0_randomized_gear)
 
-        self.verticalLayout_6 = QVBoxLayout()
-        self.verticalLayout_6.setObjectName(u"verticalLayout_6")
+        self.layoutV_for_1_gear_buttons = QVBoxLayout()
+        self.layoutV_for_1_gear_buttons.setObjectName(u"layoutV_for_1_gear_buttons")
         self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
-        self.verticalLayout_6.addItem(self.verticalSpacer)
+        self.layoutV_for_1_gear_buttons.addItem(self.verticalSpacer)
 
         self.remove_gear = QPushButton(self.tab_starting_items)
         self.remove_gear.setObjectName(u"remove_gear")
         self.remove_gear.setMinimumSize(QSize(0, 80))
 
-        self.verticalLayout_6.addWidget(self.remove_gear)
+        self.layoutV_for_1_gear_buttons.addWidget(self.remove_gear)
 
         self.add_gear = QPushButton(self.tab_starting_items)
         self.add_gear.setObjectName(u"add_gear")
         self.add_gear.setMinimumSize(QSize(0, 80))
 
-        self.verticalLayout_6.addWidget(self.add_gear)
+        self.layoutV_for_1_gear_buttons.addWidget(self.add_gear)
 
         self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
-        self.verticalLayout_6.addItem(self.verticalSpacer_2)
+        self.layoutV_for_1_gear_buttons.addItem(self.verticalSpacer_2)
 
 
-        self.horizontalLayout_6.addLayout(self.verticalLayout_6)
+        self.layoutH_for_0_gear.addLayout(self.layoutV_for_1_gear_buttons)
 
-        self.verticalLayout_7 = QVBoxLayout()
-        self.verticalLayout_7.setObjectName(u"verticalLayout_7")
+        self.layoutV_for_2_starting_gear = QVBoxLayout()
+        self.layoutV_for_2_starting_gear.setObjectName(u"layoutV_for_2_starting_gear")
         self.label_for_starting_gear = QLabel(self.tab_starting_items)
         self.label_for_starting_gear.setObjectName(u"label_for_starting_gear")
 
-        self.verticalLayout_7.addWidget(self.label_for_starting_gear)
+        self.layoutV_for_2_starting_gear.addWidget(self.label_for_starting_gear)
 
         self.starting_gear = QListView(self.tab_starting_items)
         self.starting_gear.setObjectName(u"starting_gear")
         self.starting_gear.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.starting_gear.setSelectionMode(QAbstractItemView.ExtendedSelection)
 
-        self.verticalLayout_7.addWidget(self.starting_gear)
+        self.layoutV_for_2_starting_gear.addWidget(self.starting_gear)
 
 
-        self.horizontalLayout_6.addLayout(self.verticalLayout_7)
+        self.layoutH_for_0_gear.addLayout(self.layoutV_for_2_starting_gear)
 
 
-        self.verticalLayout_4.addLayout(self.horizontalLayout_6)
+        self.verticalLayout_4.addLayout(self.layoutH_for_0_gear)
 
-        self.horizontalLayout_7 = QHBoxLayout()
-        self.horizontalLayout_7.setObjectName(u"horizontalLayout_7")
+        self.layoutH_for_1_health = QHBoxLayout()
+        self.layoutH_for_1_health.setObjectName(u"layoutH_for_1_health")
         self.label_for_starting_hcs = QLabel(self.tab_starting_items)
         self.label_for_starting_hcs.setObjectName(u"label_for_starting_hcs")
 
-        self.horizontalLayout_7.addWidget(self.label_for_starting_hcs)
+        self.layoutH_for_1_health.addWidget(self.label_for_starting_hcs)
 
         self.starting_hcs = QSpinBox(self.tab_starting_items)
         self.starting_hcs.setObjectName(u"starting_hcs")
@@ -548,12 +553,12 @@ class Ui_MainWindow(object):
         self.starting_hcs.setValue(0)
         self.starting_hcs.setDisplayIntegerBase(10)
 
-        self.horizontalLayout_7.addWidget(self.starting_hcs)
+        self.layoutH_for_1_health.addWidget(self.starting_hcs)
 
         self.label_for_starting_pohs = QLabel(self.tab_starting_items)
         self.label_for_starting_pohs.setObjectName(u"label_for_starting_pohs")
 
-        self.horizontalLayout_7.addWidget(self.label_for_starting_pohs)
+        self.layoutH_for_1_health.addWidget(self.label_for_starting_pohs)
 
         self.starting_pohs = QSpinBox(self.tab_starting_items)
         self.starting_pohs.setObjectName(u"starting_pohs")
@@ -561,44 +566,44 @@ class Ui_MainWindow(object):
         self.starting_pohs.setValue(0)
         self.starting_pohs.setDisplayIntegerBase(10)
 
-        self.horizontalLayout_7.addWidget(self.starting_pohs)
+        self.layoutH_for_1_health.addWidget(self.starting_pohs)
 
         self.current_health = QLabel(self.tab_starting_items)
         self.current_health.setObjectName(u"current_health")
 
-        self.horizontalLayout_7.addWidget(self.current_health)
+        self.layoutH_for_1_health.addWidget(self.current_health)
 
-        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.zzzz_spacerH_for_health = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout_7.addItem(self.horizontalSpacer_3)
+        self.layoutH_for_1_health.addItem(self.zzzz_spacerH_for_health)
 
 
-        self.verticalLayout_4.addLayout(self.horizontalLayout_7)
+        self.verticalLayout_4.addLayout(self.layoutH_for_1_health)
 
-        self.tabWidget.addTab(self.tab_starting_items, "")
+        self.tabs_for_primary.addTab(self.tab_starting_items, "")
         self.tab_advanced = QWidget()
         self.tab_advanced.setObjectName(u"tab_advanced")
         self.verticalLayout_8 = QVBoxLayout(self.tab_advanced)
         self.verticalLayout_8.setObjectName(u"verticalLayout_8")
-        self.groupBox_4 = QGroupBox(self.tab_advanced)
-        self.groupBox_4.setObjectName(u"groupBox_4")
-        self.gridLayout_6 = QGridLayout(self.groupBox_4)
+        self.layoutG_for_0_bosses = QGroupBox(self.tab_advanced)
+        self.layoutG_for_0_bosses.setObjectName(u"layoutG_for_0_bosses")
+        self.gridLayout_6 = QGridLayout(self.layoutG_for_0_bosses)
         self.gridLayout_6.setObjectName(u"gridLayout_6")
-        self.required_bosses = QCheckBox(self.groupBox_4)
+        self.required_bosses = QCheckBox(self.layoutG_for_0_bosses)
         self.required_bosses.setObjectName(u"required_bosses")
 
         self.gridLayout_6.addWidget(self.required_bosses, 0, 0, 1, 1)
 
-        self.horizontalLayout_8 = QHBoxLayout()
-        self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
-        self.label_for_num_required_bosses = QLabel(self.groupBox_4)
+        self.layoutH_for_0_bosses = QHBoxLayout()
+        self.layoutH_for_0_bosses.setObjectName(u"layoutH_for_0_bosses")
+        self.label_for_num_required_bosses = QLabel(self.layoutG_for_0_bosses)
         self.label_for_num_required_bosses.setObjectName(u"label_for_num_required_bosses")
         sizePolicy1.setHeightForWidth(self.label_for_num_required_bosses.sizePolicy().hasHeightForWidth())
         self.label_for_num_required_bosses.setSizePolicy(sizePolicy1)
 
-        self.horizontalLayout_8.addWidget(self.label_for_num_required_bosses)
+        self.layoutH_for_0_bosses.addWidget(self.label_for_num_required_bosses)
 
-        self.num_required_bosses = QComboBox(self.groupBox_4)
+        self.num_required_bosses = QComboBox(self.layoutG_for_0_bosses)
         self.num_required_bosses.addItem("")
         self.num_required_bosses.addItem("")
         self.num_required_bosses.addItem("")
@@ -610,256 +615,256 @@ class Ui_MainWindow(object):
         self.num_required_bosses.setSizePolicy(sizePolicy)
         self.num_required_bosses.setMaximumSize(QSize(40, 16777215))
 
-        self.horizontalLayout_8.addWidget(self.num_required_bosses)
+        self.layoutH_for_0_bosses.addWidget(self.num_required_bosses)
 
-        self.widget_3 = QWidget(self.groupBox_4)
+        self.widget_3 = QWidget(self.layoutG_for_0_bosses)
         self.widget_3.setObjectName(u"widget_3")
 
-        self.horizontalLayout_8.addWidget(self.widget_3)
+        self.layoutH_for_0_bosses.addWidget(self.widget_3)
 
 
-        self.gridLayout_6.addLayout(self.horizontalLayout_8, 0, 1, 1, 1)
+        self.gridLayout_6.addLayout(self.layoutH_for_0_bosses, 0, 1, 1, 1)
 
-        self.widget_4 = QWidget(self.groupBox_4)
+        self.widget_4 = QWidget(self.layoutG_for_0_bosses)
         self.widget_4.setObjectName(u"widget_4")
 
         self.gridLayout_6.addWidget(self.widget_4, 0, 2, 1, 1)
 
-        self.widget_5 = QWidget(self.groupBox_4)
+        self.widget_5 = QWidget(self.layoutG_for_0_bosses)
         self.widget_5.setObjectName(u"widget_5")
 
         self.gridLayout_6.addWidget(self.widget_5, 0, 3, 1, 1)
 
 
-        self.verticalLayout_8.addWidget(self.groupBox_4)
+        self.verticalLayout_8.addWidget(self.layoutG_for_0_bosses)
 
-        self.groupBox_9 = QGroupBox(self.tab_advanced)
-        self.groupBox_9.setObjectName(u"groupBox_9")
-        self.horizontalLayout_22 = QHBoxLayout(self.groupBox_9)
+        self.layoutG_for_1_logic = QGroupBox(self.tab_advanced)
+        self.layoutG_for_1_logic.setObjectName(u"layoutG_for_1_logic")
+        self.horizontalLayout_22 = QHBoxLayout(self.layoutG_for_1_logic)
         self.horizontalLayout_22.setObjectName(u"horizontalLayout_22")
-        self.horizontalLayout_20 = QHBoxLayout()
-        self.horizontalLayout_20.setObjectName(u"horizontalLayout_20")
-        self.label_for_logic_obscurity = QLabel(self.groupBox_9)
+        self.layoutH_for_0_obscurity = QHBoxLayout()
+        self.layoutH_for_0_obscurity.setObjectName(u"layoutH_for_0_obscurity")
+        self.label_for_logic_obscurity = QLabel(self.layoutG_for_1_logic)
         self.label_for_logic_obscurity.setObjectName(u"label_for_logic_obscurity")
 
-        self.horizontalLayout_20.addWidget(self.label_for_logic_obscurity)
+        self.layoutH_for_0_obscurity.addWidget(self.label_for_logic_obscurity)
 
-        self.logic_obscurity = QComboBox(self.groupBox_9)
+        self.logic_obscurity = QComboBox(self.layoutG_for_1_logic)
         self.logic_obscurity.addItem("")
         self.logic_obscurity.addItem("")
         self.logic_obscurity.addItem("")
         self.logic_obscurity.addItem("")
         self.logic_obscurity.setObjectName(u"logic_obscurity")
 
-        self.horizontalLayout_20.addWidget(self.logic_obscurity)
+        self.layoutH_for_0_obscurity.addWidget(self.logic_obscurity)
 
 
-        self.horizontalLayout_22.addLayout(self.horizontalLayout_20)
+        self.horizontalLayout_22.addLayout(self.layoutH_for_0_obscurity)
 
-        self.horizontalLayout_21 = QHBoxLayout()
-        self.horizontalLayout_21.setObjectName(u"horizontalLayout_21")
-        self.label_for_logic_precision = QLabel(self.groupBox_9)
+        self.layoutH_for_1_precision = QHBoxLayout()
+        self.layoutH_for_1_precision.setObjectName(u"layoutH_for_1_precision")
+        self.label_for_logic_precision = QLabel(self.layoutG_for_1_logic)
         self.label_for_logic_precision.setObjectName(u"label_for_logic_precision")
 
-        self.horizontalLayout_21.addWidget(self.label_for_logic_precision)
+        self.layoutH_for_1_precision.addWidget(self.label_for_logic_precision)
 
-        self.logic_precision = QComboBox(self.groupBox_9)
+        self.logic_precision = QComboBox(self.layoutG_for_1_logic)
         self.logic_precision.addItem("")
         self.logic_precision.addItem("")
         self.logic_precision.addItem("")
         self.logic_precision.addItem("")
         self.logic_precision.setObjectName(u"logic_precision")
 
-        self.horizontalLayout_21.addWidget(self.logic_precision)
+        self.layoutH_for_1_precision.addWidget(self.logic_precision)
 
 
-        self.horizontalLayout_22.addLayout(self.horizontalLayout_21)
+        self.horizontalLayout_22.addLayout(self.layoutH_for_1_precision)
 
-        self.widget_10 = QWidget(self.groupBox_9)
+        self.widget_10 = QWidget(self.layoutG_for_1_logic)
         self.widget_10.setObjectName(u"widget_10")
 
         self.horizontalLayout_22.addWidget(self.widget_10)
 
-        self.widget_13 = QWidget(self.groupBox_9)
+        self.widget_13 = QWidget(self.layoutG_for_1_logic)
         self.widget_13.setObjectName(u"widget_13")
 
         self.horizontalLayout_22.addWidget(self.widget_13)
 
 
-        self.verticalLayout_8.addWidget(self.groupBox_9)
+        self.verticalLayout_8.addWidget(self.layoutG_for_1_logic)
 
-        self.groupBox_5 = QGroupBox(self.tab_advanced)
-        self.groupBox_5.setObjectName(u"groupBox_5")
-        self.gridLayout_7 = QGridLayout(self.groupBox_5)
+        self.layoutG_for_2_hints = QGroupBox(self.tab_advanced)
+        self.layoutG_for_2_hints.setObjectName(u"layoutG_for_2_hints")
+        self.gridLayout_7 = QGridLayout(self.layoutG_for_2_hints)
         self.gridLayout_7.setObjectName(u"gridLayout_7")
-        self.hoho_hints = QCheckBox(self.groupBox_5)
+        self.hoho_hints = QCheckBox(self.layoutG_for_2_hints)
         self.hoho_hints.setObjectName(u"hoho_hints")
         self.hoho_hints.setChecked(True)
 
         self.gridLayout_7.addWidget(self.hoho_hints, 4, 0, 1, 1)
 
-        self.prioritize_remote_hints = QCheckBox(self.groupBox_5)
+        self.prioritize_remote_hints = QCheckBox(self.layoutG_for_2_hints)
         self.prioritize_remote_hints.setObjectName(u"prioritize_remote_hints")
 
         self.gridLayout_7.addWidget(self.prioritize_remote_hints, 6, 1, 1, 1)
 
-        self.korl_hints = QCheckBox(self.groupBox_5)
+        self.korl_hints = QCheckBox(self.layoutG_for_2_hints)
         self.korl_hints.setObjectName(u"korl_hints")
 
         self.gridLayout_7.addWidget(self.korl_hints, 4, 2, 1, 1)
 
-        self.horizontalLayout_16 = QHBoxLayout()
-        self.horizontalLayout_16.setObjectName(u"horizontalLayout_16")
-        self.label_for_num_barren_hints = QLabel(self.groupBox_5)
+        self.layoutH_for_2_barren_hints = QHBoxLayout()
+        self.layoutH_for_2_barren_hints.setObjectName(u"layoutH_for_2_barren_hints")
+        self.label_for_num_barren_hints = QLabel(self.layoutG_for_2_hints)
         self.label_for_num_barren_hints.setObjectName(u"label_for_num_barren_hints")
 
-        self.horizontalLayout_16.addWidget(self.label_for_num_barren_hints)
+        self.layoutH_for_2_barren_hints.addWidget(self.label_for_num_barren_hints)
 
-        self.num_barren_hints = QSpinBox(self.groupBox_5)
+        self.num_barren_hints = QSpinBox(self.layoutG_for_2_hints)
         self.num_barren_hints.setObjectName(u"num_barren_hints")
         self.num_barren_hints.setCorrectionMode(QAbstractSpinBox.CorrectToNearestValue)
         self.num_barren_hints.setMinimum(0)
         self.num_barren_hints.setMaximum(15)
         self.num_barren_hints.setValue(0)
 
-        self.horizontalLayout_16.addWidget(self.num_barren_hints)
+        self.layoutH_for_2_barren_hints.addWidget(self.num_barren_hints)
 
-        self.widget_7 = QWidget(self.groupBox_5)
+        self.widget_7 = QWidget(self.layoutG_for_2_hints)
         self.widget_7.setObjectName(u"widget_7")
 
-        self.horizontalLayout_16.addWidget(self.widget_7)
+        self.layoutH_for_2_barren_hints.addWidget(self.widget_7)
 
 
-        self.gridLayout_7.addLayout(self.horizontalLayout_16, 5, 2, 1, 1)
+        self.gridLayout_7.addLayout(self.layoutH_for_2_barren_hints, 5, 2, 1, 1)
 
-        self.cryptic_hints = QCheckBox(self.groupBox_5)
+        self.cryptic_hints = QCheckBox(self.layoutG_for_2_hints)
         self.cryptic_hints.setObjectName(u"cryptic_hints")
         self.cryptic_hints.setChecked(True)
 
         self.gridLayout_7.addWidget(self.cryptic_hints, 6, 0, 1, 1)
 
-        self.fishmen_hints = QCheckBox(self.groupBox_5)
+        self.fishmen_hints = QCheckBox(self.layoutG_for_2_hints)
         self.fishmen_hints.setObjectName(u"fishmen_hints")
         self.fishmen_hints.setChecked(True)
 
         self.gridLayout_7.addWidget(self.fishmen_hints, 4, 1, 1, 1)
 
-        self.horizontalLayout_17 = QHBoxLayout()
-        self.horizontalLayout_17.setObjectName(u"horizontalLayout_17")
-        self.label_for_num_location_hints = QLabel(self.groupBox_5)
+        self.layoutH_for_1_location_hints = QHBoxLayout()
+        self.layoutH_for_1_location_hints.setObjectName(u"layoutH_for_1_location_hints")
+        self.label_for_num_location_hints = QLabel(self.layoutG_for_2_hints)
         self.label_for_num_location_hints.setObjectName(u"label_for_num_location_hints")
 
-        self.horizontalLayout_17.addWidget(self.label_for_num_location_hints)
+        self.layoutH_for_1_location_hints.addWidget(self.label_for_num_location_hints)
 
-        self.num_location_hints = QSpinBox(self.groupBox_5)
+        self.num_location_hints = QSpinBox(self.layoutG_for_2_hints)
         self.num_location_hints.setObjectName(u"num_location_hints")
         self.num_location_hints.setCorrectionMode(QAbstractSpinBox.CorrectToNearestValue)
         self.num_location_hints.setMinimum(0)
         self.num_location_hints.setMaximum(15)
         self.num_location_hints.setValue(5)
 
-        self.horizontalLayout_17.addWidget(self.num_location_hints)
+        self.layoutH_for_1_location_hints.addWidget(self.num_location_hints)
 
-        self.widget_8 = QWidget(self.groupBox_5)
+        self.widget_8 = QWidget(self.layoutG_for_2_hints)
         self.widget_8.setObjectName(u"widget_8")
 
-        self.horizontalLayout_17.addWidget(self.widget_8)
+        self.layoutH_for_1_location_hints.addWidget(self.widget_8)
 
 
-        self.gridLayout_7.addLayout(self.horizontalLayout_17, 5, 1, 1, 1)
+        self.gridLayout_7.addLayout(self.layoutH_for_1_location_hints, 5, 1, 1, 1)
 
-        self.horizontalLayout_9 = QHBoxLayout()
-        self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
-        self.label_for_num_item_hints = QLabel(self.groupBox_5)
+        self.layoutH_for_0_item_hints = QHBoxLayout()
+        self.layoutH_for_0_item_hints.setObjectName(u"layoutH_for_0_item_hints")
+        self.label_for_num_item_hints = QLabel(self.layoutG_for_2_hints)
         self.label_for_num_item_hints.setObjectName(u"label_for_num_item_hints")
 
-        self.horizontalLayout_9.addWidget(self.label_for_num_item_hints)
+        self.layoutH_for_0_item_hints.addWidget(self.label_for_num_item_hints)
 
-        self.num_item_hints = QSpinBox(self.groupBox_5)
+        self.num_item_hints = QSpinBox(self.layoutG_for_2_hints)
         self.num_item_hints.setObjectName(u"num_item_hints")
         self.num_item_hints.setCorrectionMode(QAbstractSpinBox.CorrectToNearestValue)
         self.num_item_hints.setMinimum(0)
         self.num_item_hints.setMaximum(15)
         self.num_item_hints.setValue(15)
 
-        self.horizontalLayout_9.addWidget(self.num_item_hints)
+        self.layoutH_for_0_item_hints.addWidget(self.num_item_hints)
 
-        self.widget_9 = QWidget(self.groupBox_5)
+        self.widget_9 = QWidget(self.layoutG_for_2_hints)
         self.widget_9.setObjectName(u"widget_9")
 
-        self.horizontalLayout_9.addWidget(self.widget_9)
+        self.layoutH_for_0_item_hints.addWidget(self.widget_9)
 
 
-        self.gridLayout_7.addLayout(self.horizontalLayout_9, 5, 0, 1, 1)
+        self.gridLayout_7.addLayout(self.layoutH_for_0_item_hints, 5, 0, 1, 1)
 
-        self.horizontalLayout_15 = QHBoxLayout()
-        self.horizontalLayout_15.setObjectName(u"horizontalLayout_15")
-        self.label_for_num_path_hints = QLabel(self.groupBox_5)
+        self.layoutH_for_3_path_hints = QHBoxLayout()
+        self.layoutH_for_3_path_hints.setObjectName(u"layoutH_for_3_path_hints")
+        self.label_for_num_path_hints = QLabel(self.layoutG_for_2_hints)
         self.label_for_num_path_hints.setObjectName(u"label_for_num_path_hints")
 
-        self.horizontalLayout_15.addWidget(self.label_for_num_path_hints)
+        self.layoutH_for_3_path_hints.addWidget(self.label_for_num_path_hints)
 
-        self.num_path_hints = QSpinBox(self.groupBox_5)
+        self.num_path_hints = QSpinBox(self.layoutG_for_2_hints)
         self.num_path_hints.setObjectName(u"num_path_hints")
         self.num_path_hints.setCorrectionMode(QAbstractSpinBox.CorrectToNearestValue)
         self.num_path_hints.setMinimum(0)
         self.num_path_hints.setMaximum(15)
         self.num_path_hints.setValue(0)
 
-        self.horizontalLayout_15.addWidget(self.num_path_hints)
+        self.layoutH_for_3_path_hints.addWidget(self.num_path_hints)
 
-        self.widget_6 = QWidget(self.groupBox_5)
+        self.widget_6 = QWidget(self.layoutG_for_2_hints)
         self.widget_6.setObjectName(u"widget_6")
 
-        self.horizontalLayout_15.addWidget(self.widget_6)
+        self.layoutH_for_3_path_hints.addWidget(self.widget_6)
 
 
-        self.gridLayout_7.addLayout(self.horizontalLayout_15, 5, 3, 1, 1)
+        self.gridLayout_7.addLayout(self.layoutH_for_3_path_hints, 5, 3, 1, 1)
 
 
-        self.verticalLayout_8.addWidget(self.groupBox_5)
+        self.verticalLayout_8.addWidget(self.layoutG_for_2_hints)
 
-        self.groupBox_6 = QGroupBox(self.tab_advanced)
-        self.groupBox_6.setObjectName(u"groupBox_6")
-        self.gridLayout_8 = QGridLayout(self.groupBox_6)
+        self.layoutG_for_3_advanced = QGroupBox(self.tab_advanced)
+        self.layoutG_for_3_advanced.setObjectName(u"layoutG_for_3_advanced")
+        self.gridLayout_8 = QGridLayout(self.layoutG_for_3_advanced)
         self.gridLayout_8.setObjectName(u"gridLayout_8")
-        self.do_not_generate_spoiler_log = QCheckBox(self.groupBox_6)
+        self.do_not_generate_spoiler_log = QCheckBox(self.layoutG_for_3_advanced)
         self.do_not_generate_spoiler_log.setObjectName(u"do_not_generate_spoiler_log")
 
         self.gridLayout_8.addWidget(self.do_not_generate_spoiler_log, 0, 0, 1, 1)
 
-        self.widget_11 = QWidget(self.groupBox_6)
+        self.widget_11 = QWidget(self.layoutG_for_3_advanced)
         self.widget_11.setObjectName(u"widget_11")
 
         self.gridLayout_8.addWidget(self.widget_11, 0, 2, 1, 1)
 
-        self.widget_12 = QWidget(self.groupBox_6)
+        self.widget_12 = QWidget(self.layoutG_for_3_advanced)
         self.widget_12.setObjectName(u"widget_12")
 
         self.gridLayout_8.addWidget(self.widget_12, 0, 3, 1, 1)
 
-        self.dry_run = QCheckBox(self.groupBox_6)
+        self.dry_run = QCheckBox(self.layoutG_for_3_advanced)
         self.dry_run.setObjectName(u"dry_run")
 
         self.gridLayout_8.addWidget(self.dry_run, 0, 1, 1, 1)
 
 
-        self.verticalLayout_8.addWidget(self.groupBox_6)
+        self.verticalLayout_8.addWidget(self.layoutG_for_3_advanced)
 
-        self.verticalSpacer_3 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.zzzz_spacerV_for_advanced = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
-        self.verticalLayout_8.addItem(self.verticalSpacer_3)
+        self.verticalLayout_8.addItem(self.zzzz_spacerV_for_advanced)
 
-        self.tabWidget.addTab(self.tab_advanced, "")
+        self.tabs_for_primary.addTab(self.tab_advanced, "")
         self.tab_player_customization = CosmeticTab()
         self.tab_player_customization.setObjectName(u"tab_player_customization")
-        self.tabWidget.addTab(self.tab_player_customization, "")
+        self.tabs_for_primary.addTab(self.tab_player_customization, "")
 
-        self.verticalLayout_2.addWidget(self.tabWidget)
+        self.verticalLayout_2.addWidget(self.tabs_for_primary)
 
-        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+        self.layoutS_for_0_primary.setWidget(self.scrollA_for_primary)
 
-        self.verticalLayout.addWidget(self.scrollArea)
+        self.verticalLayout.addWidget(self.layoutS_for_0_primary)
 
         self.option_description = QLabel(self.centralwidget)
         self.option_description.setObjectName(u"option_description")
@@ -869,20 +874,20 @@ class Ui_MainWindow(object):
 
         self.verticalLayout.addWidget(self.option_description)
 
-        self.horizontalLayout = QHBoxLayout()
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.layoutH_for_2_permalink = QHBoxLayout()
+        self.layoutH_for_2_permalink.setObjectName(u"layoutH_for_2_permalink")
         self.label_for_permalink = QLabel(self.centralwidget)
         self.label_for_permalink.setObjectName(u"label_for_permalink")
 
-        self.horizontalLayout.addWidget(self.label_for_permalink)
+        self.layoutH_for_2_permalink.addWidget(self.label_for_permalink)
 
         self.permalink = QLineEdit(self.centralwidget)
         self.permalink.setObjectName(u"permalink")
 
-        self.horizontalLayout.addWidget(self.permalink)
+        self.layoutH_for_2_permalink.addWidget(self.permalink)
 
 
-        self.verticalLayout.addLayout(self.horizontalLayout)
+        self.verticalLayout.addLayout(self.layoutH_for_2_permalink)
 
         self.update_checker_label = QLabel(self.centralwidget)
         self.update_checker_label.setObjectName(u"update_checker_label")
@@ -890,37 +895,37 @@ class Ui_MainWindow(object):
 
         self.verticalLayout.addWidget(self.update_checker_label)
 
-        self.horizontalLayout_2 = QHBoxLayout()
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.layoutH_for_4_buttons = QHBoxLayout()
+        self.layoutH_for_4_buttons.setObjectName(u"layoutH_for_4_buttons")
         self.about_button = QPushButton(self.centralwidget)
         self.about_button.setObjectName(u"about_button")
 
-        self.horizontalLayout_2.addWidget(self.about_button)
+        self.layoutH_for_4_buttons.addWidget(self.about_button)
 
-        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.zzzz_spacerH_for_about = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout_2.addItem(self.horizontalSpacer)
+        self.layoutH_for_4_buttons.addItem(self.zzzz_spacerH_for_about)
 
         self.reset_settings_to_default = QPushButton(self.centralwidget)
         self.reset_settings_to_default.setObjectName(u"reset_settings_to_default")
         self.reset_settings_to_default.setMinimumSize(QSize(180, 0))
 
-        self.horizontalLayout_2.addWidget(self.reset_settings_to_default)
+        self.layoutH_for_4_buttons.addWidget(self.reset_settings_to_default)
 
-        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.zzzz_spacerH_for_default = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout_2.addItem(self.horizontalSpacer_2)
+        self.layoutH_for_4_buttons.addItem(self.zzzz_spacerH_for_default)
 
         self.randomize_button = QPushButton(self.centralwidget)
         self.randomize_button.setObjectName(u"randomize_button")
 
-        self.horizontalLayout_2.addWidget(self.randomize_button)
+        self.layoutH_for_4_buttons.addWidget(self.randomize_button)
 
 
-        self.verticalLayout.addLayout(self.horizontalLayout_2)
+        self.verticalLayout.addLayout(self.layoutH_for_4_buttons)
 
         MainWindow.setCentralWidget(self.centralwidget)
-        QWidget.setTabOrder(self.scrollArea, self.clean_iso_path)
+        QWidget.setTabOrder(self.layoutS_for_0_primary, self.clean_iso_path)
         QWidget.setTabOrder(self.clean_iso_path, self.clean_iso_path_browse_button)
         QWidget.setTabOrder(self.clean_iso_path_browse_button, self.output_folder)
         QWidget.setTabOrder(self.output_folder, self.output_folder_browse_button)
@@ -960,7 +965,7 @@ class Ui_MainWindow(object):
 
         self.retranslateUi(MainWindow)
 
-        self.tabWidget.setCurrentIndex(0)
+        self.tabs_for_primary.setCurrentIndex(0)
         self.num_required_bosses.setCurrentIndex(3)
 
 
@@ -976,30 +981,30 @@ class Ui_MainWindow(object):
         self.generate_seed_button.setText(QCoreApplication.translate("MainWindow", u"New seed", None))
         self.clean_iso_path_browse_button.setText(QCoreApplication.translate("MainWindow", u"Browse", None))
         self.progression_locations_groupbox.setTitle(QCoreApplication.translate("MainWindow", u"Progression Locations: Where Should Progress Items Be Placed?", None))
-        self.progression_platforms_rafts.setText(QCoreApplication.translate("MainWindow", u"Lookout Platforms and Rafts", None))
-        self.progression_expensive_purchases.setText(QCoreApplication.translate("MainWindow", u"Expensive Purchases", None))
-        self.progression_dungeon_secrets.setText(QCoreApplication.translate("MainWindow", u"Dungeon Secrets", None))
-        self.progression_treasure_charts.setText(QCoreApplication.translate("MainWindow", u"Sunken Treasure (From Treasure Charts)", None))
-        self.progression_tingle_chests.setText(QCoreApplication.translate("MainWindow", u"Tingle Chests", None))
-        self.progression_savage_labyrinth.setText(QCoreApplication.translate("MainWindow", u"Savage Labyrinth", None))
         self.progression_dungeons.setText(QCoreApplication.translate("MainWindow", u"Dungeons", None))
-        self.progression_triforce_charts.setText(QCoreApplication.translate("MainWindow", u"Sunken Treasure (From Triforce Charts)", None))
-        self.progression_combat_secret_caves.setText(QCoreApplication.translate("MainWindow", u"Combat Secret Caves", None))
-        self.progression_big_octos_gunboats.setText(QCoreApplication.translate("MainWindow", u"Big Octos and Gunboats", None))
-        self.progression_island_puzzles.setText(QCoreApplication.translate("MainWindow", u"Island Puzzles", None))
-        self.progression_great_fairies.setText(QCoreApplication.translate("MainWindow", u"Great Fairies", None))
-        self.progression_puzzle_secret_caves.setText(QCoreApplication.translate("MainWindow", u"Puzzle Secret Caves", None))
-        self.progression_battlesquid.setText(QCoreApplication.translate("MainWindow", u"Battlesquid Minigame", None))
-        self.progression_minigames.setText(QCoreApplication.translate("MainWindow", u"Minigames", None))
-        self.progression_misc.setText(QCoreApplication.translate("MainWindow", u"Miscellaneous", None))
-        self.progression_submarines.setText(QCoreApplication.translate("MainWindow", u"Submarines", None))
-        self.progression_short_sidequests.setText(QCoreApplication.translate("MainWindow", u"Short Sidequests", None))
+        self.progression_tingle_chests.setText(QCoreApplication.translate("MainWindow", u"Tingle Chests", None))
         self.progression_long_sidequests.setText(QCoreApplication.translate("MainWindow", u"Long Sidequests", None))
         self.progression_spoils_trading.setText(QCoreApplication.translate("MainWindow", u"Spoils Trading", None))
-        self.progression_eye_reef_chests.setText(QCoreApplication.translate("MainWindow", u"Eye Reef Chests", None))
-        self.progression_free_gifts.setText(QCoreApplication.translate("MainWindow", u"Free Gifts", None))
+        self.progression_short_sidequests.setText(QCoreApplication.translate("MainWindow", u"Short Sidequests", None))
+        self.progression_puzzle_secret_caves.setText(QCoreApplication.translate("MainWindow", u"Puzzle Secret Caves", None))
+        self.progression_savage_labyrinth.setText(QCoreApplication.translate("MainWindow", u"Savage Labyrinth", None))
+        self.progression_combat_secret_caves.setText(QCoreApplication.translate("MainWindow", u"Combat Secret Caves", None))
+        self.progression_dungeon_secrets.setText(QCoreApplication.translate("MainWindow", u"Dungeon Secrets", None))
+        self.progression_battlesquid.setText(QCoreApplication.translate("MainWindow", u"Battlesquid Minigame", None))
         self.progression_mail.setText(QCoreApplication.translate("MainWindow", u"Mail", None))
-        self.groupBox_2.setTitle(QCoreApplication.translate("MainWindow", u"Item Randomizer Modes", None))
+        self.progression_great_fairies.setText(QCoreApplication.translate("MainWindow", u"Great Fairies", None))
+        self.progression_misc.setText(QCoreApplication.translate("MainWindow", u"Miscellaneous", None))
+        self.progression_treasure_charts.setText(QCoreApplication.translate("MainWindow", u"Sunken Treasure (From Treasure Charts)", None))
+        self.progression_triforce_charts.setText(QCoreApplication.translate("MainWindow", u"Sunken Treasure (From Triforce Charts)", None))
+        self.progression_expensive_purchases.setText(QCoreApplication.translate("MainWindow", u"Expensive Purchases", None))
+        self.progression_minigames.setText(QCoreApplication.translate("MainWindow", u"Minigames", None))
+        self.progression_submarines.setText(QCoreApplication.translate("MainWindow", u"Submarines", None))
+        self.progression_big_octos_gunboats.setText(QCoreApplication.translate("MainWindow", u"Big Octos and Gunboats", None))
+        self.progression_platforms_rafts.setText(QCoreApplication.translate("MainWindow", u"Lookout Platforms and Rafts", None))
+        self.progression_free_gifts.setText(QCoreApplication.translate("MainWindow", u"Free Gifts", None))
+        self.progression_island_puzzles.setText(QCoreApplication.translate("MainWindow", u"Island Puzzles", None))
+        self.progression_eye_reef_chests.setText(QCoreApplication.translate("MainWindow", u"Eye Reef Chests", None))
+        self.layoutG_for_2_item_randomizers.setTitle(QCoreApplication.translate("MainWindow", u"Item Randomizer Modes", None))
         self.label_for_sword_mode.setText(QCoreApplication.translate("MainWindow", u"Sword Mode", None))
         self.sword_mode.setItemText(0, QCoreApplication.translate("MainWindow", u"Start with Hero's Sword", None))
         self.sword_mode.setItemText(1, QCoreApplication.translate("MainWindow", u"No Starting Sword", None))
@@ -1018,23 +1023,23 @@ class Ui_MainWindow(object):
 
         self.chest_type_matches_contents.setText(QCoreApplication.translate("MainWindow", u"Chest Type Matches Contents", None))
         self.keylunacy.setText(QCoreApplication.translate("MainWindow", u"Key-Lunacy", None))
-        self.groupBox_7.setTitle(QCoreApplication.translate("MainWindow", u"Entrance Randomizer Options", None))
-        self.randomize_miniboss_entrances.setText(QCoreApplication.translate("MainWindow", u"Nested Minibosses", None))
-        self.randomize_dungeon_entrances.setText(QCoreApplication.translate("MainWindow", u"Dungeons", None))
-        self.randomize_secret_cave_entrances.setText(QCoreApplication.translate("MainWindow", u"Secret Caves", None))
+        self.layoutG_for_0_entrance.setTitle(QCoreApplication.translate("MainWindow", u"Entrance Randomizer Options", None))
         self.randomize_boss_entrances.setText(QCoreApplication.translate("MainWindow", u"Nested Bosses", None))
-        self.randomize_secret_cave_inner_entrances.setText(QCoreApplication.translate("MainWindow", u"Inner Secret Caves", None))
         self.randomize_fairy_fountain_entrances.setText(QCoreApplication.translate("MainWindow", u"Fairy Fountains", None))
+        self.randomize_secret_cave_inner_entrances.setText(QCoreApplication.translate("MainWindow", u"Inner Secret Caves", None))
+        self.randomize_secret_cave_entrances.setText(QCoreApplication.translate("MainWindow", u"Secret Caves", None))
+        self.randomize_dungeon_entrances.setText(QCoreApplication.translate("MainWindow", u"Dungeons", None))
+        self.randomize_miniboss_entrances.setText(QCoreApplication.translate("MainWindow", u"Nested Minibosses", None))
         self.label_for_mix_entrances.setText(QCoreApplication.translate("MainWindow", u"Mixing", None))
         self.mix_entrances.setItemText(0, QCoreApplication.translate("MainWindow", u"Separate Dungeons From Caves & Fountains", None))
         self.mix_entrances.setItemText(1, QCoreApplication.translate("MainWindow", u"Mix Dungeons & Caves & Fountains", None))
 
-        self.groupBox_8.setTitle(QCoreApplication.translate("MainWindow", u"Other Randomizers", None))
+        self.layoutG_for_1_other.setTitle(QCoreApplication.translate("MainWindow", u"Other Randomizers", None))
         self.randomize_enemies.setText(QCoreApplication.translate("MainWindow", u"Randomize Enemy Locations", None))
         self.randomize_charts.setText(QCoreApplication.translate("MainWindow", u"Randomize Charts", None))
         self.randomize_enemy_palettes.setText(QCoreApplication.translate("MainWindow", u"Randomize Enemy Palettes", None))
         self.randomize_starting_island.setText(QCoreApplication.translate("MainWindow", u"Randomize Starting Island", None))
-        self.groupBox_3.setTitle(QCoreApplication.translate("MainWindow", u"Convenience Tweaks", None))
+        self.layoutG_for_4_convenience.setTitle(QCoreApplication.translate("MainWindow", u"Convenience Tweaks", None))
         self.invert_sea_compass_x_axis.setText(QCoreApplication.translate("MainWindow", u"Invert Sea Compass X-Axis", None))
         self.invert_camera_x_axis.setText(QCoreApplication.translate("MainWindow", u"Invert Camera X-Axis", None))
         self.instant_text_boxes.setText(QCoreApplication.translate("MainWindow", u"Instant Text Boxes", None))
@@ -1044,7 +1049,7 @@ class Ui_MainWindow(object):
         self.skip_rematch_bosses.setText(QCoreApplication.translate("MainWindow", u"Skip Boss Rematches", None))
         self.remove_music.setText(QCoreApplication.translate("MainWindow", u"Remove Music", None))
         self.add_shortcut_warps_between_dungeons.setText(QCoreApplication.translate("MainWindow", u"Add Shortcut Warps Between Dungeons", None))
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_randomizer_settings), QCoreApplication.translate("MainWindow", u"Randomizer Settings", None))
+        self.tabs_for_primary.setTabText(self.tabs_for_primary.indexOf(self.tab_randomizer_settings), QCoreApplication.translate("MainWindow", u"Randomizer Settings", None))
         self.label_for_randomized_gear.setText(QCoreApplication.translate("MainWindow", u"Randomized Gear", None))
         self.remove_gear.setText(QCoreApplication.translate("MainWindow", u"<-", None))
         self.add_gear.setText(QCoreApplication.translate("MainWindow", u"->", None))
@@ -1052,8 +1057,8 @@ class Ui_MainWindow(object):
         self.label_for_starting_hcs.setText(QCoreApplication.translate("MainWindow", u"Heart Containers", None))
         self.label_for_starting_pohs.setText(QCoreApplication.translate("MainWindow", u"Heart Pieces", None))
         self.current_health.setText(QCoreApplication.translate("MainWindow", u"Current Starting Health: 3 hearts", None))
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_starting_items), QCoreApplication.translate("MainWindow", u"Starting Items", None))
-        self.groupBox_4.setTitle(QCoreApplication.translate("MainWindow", u"Required Bosses", None))
+        self.tabs_for_primary.setTabText(self.tabs_for_primary.indexOf(self.tab_starting_items), QCoreApplication.translate("MainWindow", u"Starting Items", None))
+        self.layoutG_for_0_bosses.setTitle(QCoreApplication.translate("MainWindow", u"Required Bosses", None))
         self.required_bosses.setText(QCoreApplication.translate("MainWindow", u"Required Bosses Mode", None))
         self.label_for_num_required_bosses.setText(QCoreApplication.translate("MainWindow", u"Number of Required Bosses", None))
         self.num_required_bosses.setItemText(0, QCoreApplication.translate("MainWindow", u"1", None))
@@ -1063,7 +1068,7 @@ class Ui_MainWindow(object):
         self.num_required_bosses.setItemText(4, QCoreApplication.translate("MainWindow", u"5", None))
         self.num_required_bosses.setItemText(5, QCoreApplication.translate("MainWindow", u"6", None))
 
-        self.groupBox_9.setTitle(QCoreApplication.translate("MainWindow", u"Logic Difficulty", None))
+        self.layoutG_for_1_logic.setTitle(QCoreApplication.translate("MainWindow", u"Logic Difficulty", None))
         self.label_for_logic_obscurity.setText(QCoreApplication.translate("MainWindow", u"Obscure Tricks Required", None))
         self.logic_obscurity.setItemText(0, QCoreApplication.translate("MainWindow", u"None", None))
         self.logic_obscurity.setItemText(1, QCoreApplication.translate("MainWindow", u"Normal", None))
@@ -1076,7 +1081,7 @@ class Ui_MainWindow(object):
         self.logic_precision.setItemText(2, QCoreApplication.translate("MainWindow", u"Hard", None))
         self.logic_precision.setItemText(3, QCoreApplication.translate("MainWindow", u"Very Hard", None))
 
-        self.groupBox_5.setTitle(QCoreApplication.translate("MainWindow", u"Hint Options", None))
+        self.layoutG_for_2_hints.setTitle(QCoreApplication.translate("MainWindow", u"Hint Options", None))
         self.hoho_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on Old Man Ho Ho", None))
         self.prioritize_remote_hints.setText(QCoreApplication.translate("MainWindow", u"Prioritize Remote Location Hints", None))
         self.korl_hints.setText(QCoreApplication.translate("MainWindow", u"Place Hints on King of Red Lions", None))
@@ -1086,11 +1091,11 @@ class Ui_MainWindow(object):
         self.label_for_num_location_hints.setText(QCoreApplication.translate("MainWindow", u"Location Hints", None))
         self.label_for_num_item_hints.setText(QCoreApplication.translate("MainWindow", u"Item Hints", None))
         self.label_for_num_path_hints.setText(QCoreApplication.translate("MainWindow", u"Path Hints", None))
-        self.groupBox_6.setTitle(QCoreApplication.translate("MainWindow", u"Additional Advanced Options", None))
+        self.layoutG_for_3_advanced.setTitle(QCoreApplication.translate("MainWindow", u"Additional Advanced Options", None))
         self.do_not_generate_spoiler_log.setText(QCoreApplication.translate("MainWindow", u"Do Not Generate Spoiler Log", None))
         self.dry_run.setText(QCoreApplication.translate("MainWindow", u"Dry Run", None))
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_advanced), QCoreApplication.translate("MainWindow", u"Advanced Options", None))
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_player_customization), QCoreApplication.translate("MainWindow", u"Player Customization", None))
+        self.tabs_for_primary.setTabText(self.tabs_for_primary.indexOf(self.tab_advanced), QCoreApplication.translate("MainWindow", u"Advanced Options", None))
+        self.tabs_for_primary.setTabText(self.tabs_for_primary.indexOf(self.tab_player_customization), QCoreApplication.translate("MainWindow", u"Player Customization", None))
         self.option_description.setText("")
         self.label_for_permalink.setText(QCoreApplication.translate("MainWindow", u"Permalink (copy paste to share your settings):", None))
         self.update_checker_label.setText(QCoreApplication.translate("MainWindow", u"Checking for updates to the randomizer...", None))


### PR DESCRIPTION
Fixed issue with build_ui (may be machine dependent)
Changed main randomizer grid layout
- Items are organized horizontally then vertically per Discord discussion
Changed layout names to be descriptive of their contained
![image](https://github.com/LagoLunatic/wwrando/assets/7776520/c0000867-f3c4-45eb-ba68-4f41908e7b8e)
