### PR TITLE
Starting item randomizer

### DIFF
--- a/logic/logic.py
+++ b/logic/logic.py
@@ -189,6 +189,15 @@ class Logic:
         if group_name in self.unplaced_progress_items:
           self.unplaced_progress_items.remove(group_name)
     
+    # Add the randomly-selected starting items (without incidence on other progress items)
+    if self.rando.random_starting_item.is_enabled():
+      for item in self.rando.random_starting_item.random_starting_items:
+        # Needs to happen after make useless_progress_items_nonprogress
+        # To ensure other progress items aren't made nonprogress by the random
+        # items being in the starting inventory for the purpose of hints or
+        # spoiler log progression
+        self.add_owned_item_or_item_group(item)
+
     self.clear_req_caches()
     self.cached_enemies_tested_for_reqs_tuple.clear()
   

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -483,7 +483,8 @@ class Logic:
     accessible_undone_locations = self.get_accessible_remaining_locations(for_progression=True)
     inaccessible_undone_item_locations = []
     locations_to_check = self.remaining_item_locations
-    locations_to_check = self.filter_locations_for_progression(locations_to_check)
+    need_sunken_treasure = any(item.startswith("Treasure Chart ") or item.startswith("Triforce Chart ") for item in item_names_to_check)
+    locations_to_check = self.filter_locations_for_progression(locations_to_check, filter_sunken_treasure=(not need_sunken_treasure))
     for location_name in locations_to_check:
       if location_name not in accessible_undone_locations:
         if location_name in self.rando.boss_reqs.banned_locations:

--- a/randomizers/starting_item.py
+++ b/randomizers/starting_item.py
@@ -9,7 +9,6 @@ DISALLOWED_RANDOM_STARTING_ITEMS = set([
   # It's also 8 items and would have a fairly large impact on the seed, so we'd probably want
   # to weigh it less than other items if allowed
   "Triforce Shards",
-  "Progressive Sword", # Separate option for starting sword mode, not handled solely by tweaks.update_starting_gear. might be possible?
   # Other items that you can't start with in the UI, but we allow anyway:
   # "Treasure Charts", "Triforce Charts" # These seem to work fine to start with, even if not very fun
   # "Tingle Statues", # seem to work fine
@@ -108,6 +107,15 @@ class StartingItemRandomizer(BaseRandomizer):
     if set(self.logic.triforce_chart_names).intersection(available_items):
         available_items -= set(self.logic.triforce_chart_names)
         available_items.add('Triforce Chart')
+
+    # If sword_mode is No Starting Sword, adding swords would desync the
+    # sword_mode option from the actual number of swords.
+    # Swordless doesn't put the Progressive Swords in the progress items in the
+    # first place so doesn't need this
+    # This might be removable if we can make a random starting progressive sword
+    # automatically change the sword_mode variable and its consequences
+    if self.options.get("sword_mode") == "No Starting Sword" and "Progressive Sword" in available_items:
+      available_items.remove("Progressive Sword")
 
     # We need to sort before converting to lists because sets have per-process hash seeding
     # and could otherwise lead to different randomization between processes with the same seed

--- a/randomizers/starting_item.py
+++ b/randomizers/starting_item.py
@@ -52,10 +52,12 @@ class StartingItemRandomizer(BaseRandomizer):
 
       selected = self.rng.choice(available_items)
 
-      if selected == "Treasure Chart":
-        selected = self.rng.choice([chart for chart in self.logic.unplaced_progress_items if chart in self.logic.treasure_chart_names])
-      if selected == "Triforce Chart":
-        selected = self.rng.choice([chart for chart in self.logic.unplaced_progress_items if chart in self.logic.triforce_chart_names])
+      if selected in ("Treasure Chart", "Triforce Chart"):
+        chart_usefulness = self.logic.get_items_by_usefulness_fraction(self.logic.treasure_chart_names + self.logic.triforce_chart_names)
+        selected = self.rng.choice([
+          chart for chart in self.logic.unplaced_progress_items
+          if chart.startswith(selected) and chart in chart_usefulness and chart_usefulness[chart] <= max_fraction
+        ])
 
       # Sync the added items back to the other lists:
       self.logic.add_owned_item_or_item_group(selected)

--- a/randomizers/starting_item.py
+++ b/randomizers/starting_item.py
@@ -1,0 +1,128 @@
+import typing
+from logic.item_types import DUNGEON_PROGRESS_ITEMS
+
+from randomizers.base_randomizer import BaseRandomizer
+import tweaks
+
+DISALLOWED_RANDOM_STARTING_ITEMS = set([
+  # There's a separate option for number of starting triforce shards that we'd need to mess with
+  # It's also 8 items and would have a fairly large impact on the seed, so we'd probably want
+  # to weigh it less than other items if allowed
+  "Triforce Shards",
+  "Progressive Sword", # Separate option for starting sword mode, not handled solely by tweaks.update_starting_gear. might be possible?
+  # Other items that you can't start with in the UI, but we allow anyway:
+  # "Treasure Charts", "Triforce Charts" # These seem to work fine to start with, even if not very fun
+  # "Tingle Statues", # seem to work fine
+  # "Boat's Sail", "Wind Waker", "Wind's Requiem" # Mandatory starting items
+  # "Empty Bottle", # Can only start with one Empty Bottle from the UI, but seems to work ok with more
+  # DUNGEON_PROGRESS_ITEMS # Seem to work fine at least in keylunacy (enforced below)
+])
+
+DELIVERY_BAG_ITEMS = set([
+  "Note to Mom",
+  "Maggie's Letter",
+  "Moblin's Letter",
+  "Cabana Deed",
+])
+
+class StartingItemRandomizer(BaseRandomizer):
+
+  def __init__(self, rando):
+    super().__init__(rando)
+    self.random_starting_items = []
+
+  def is_enabled(self) -> bool:
+    return (
+      self.rando.items.is_enabled() and
+      self.options.get("num_random_starting_items", 0) > 0
+    )
+
+  def _randomize(self):
+    initial_sphere_0_checks = self.logic.get_accessible_remaining_locations(for_progression=True)
+    items_to_place = self.options.get("num_random_starting_items")
+    for remaining_random_starting_items in range(items_to_place, 0, -1):
+      max_fraction = remaining_random_starting_items
+      if len(self.logic.get_accessible_remaining_locations(for_progression=True)) > len(initial_sphere_0_checks):
+        # If we've already unlocked at least one check, we can use any items for the remaining slots
+        # We still want to avoid completely useless ones though (f.ex dungeon items for non-race-mode dungeons)
+        max_fraction = 9998
+      available_items = self.filter_possible_random_starting_items(max_fraction)
+
+      if len(available_items) == 0:
+        break
+
+      selected = self.rng.choice(available_items)
+
+      if selected == "Treasure Chart":
+        selected = self.rng.choice([chart for chart in self.logic.unplaced_progress_items if chart in self.logic.treasure_chart_names])
+      if selected == "Triforce Chart":
+        selected = self.rng.choice([chart for chart in self.logic.unplaced_progress_items if chart in self.logic.triforce_chart_names])
+
+      # Sync the added items back to the other lists:
+      self.logic.add_owned_item_or_item_group(selected)
+      self.rando.starting_items.extend(self.logic.expand_item_groups([selected]))
+      self.random_starting_items.append(selected)
+
+    # Confirm that we opened at least one new check if we assigned an item
+    if self.random_starting_items and len(self.logic.get_accessible_remaining_locations(for_progression=True)) <= len(initial_sphere_0_checks):
+      # This would indicate a logic bug, the filtering above should prevent it
+      raise Exception("Random starting items didn't unlock at least one check")
+      
+  def filter_possible_random_starting_items(self, max_fraction: int) -> list[str]:
+    items_by_usefulness = self.logic.get_items_by_usefulness_fraction(self.logic.get_flattened_unplaced_progression_items())
+    # Since we assign items in groups all at once, add back in synthetic items with the group names
+    available_items: set[str] = set()
+    for item, fraction in items_by_usefulness.items():
+      group_name = next(
+        (group for group, group_items in self.logic.progress_item_groups.items() 
+         if item in group_items),
+        None
+      )
+      # However we only want to merge the group if all the items are progression
+      # (specifically for pearls where Farore's can be useful without the
+      # others being progression)
+      if (
+        group_name and 
+        all((item in self.logic.get_flattened_unplaced_progression_items()) for item in self.logic.progress_item_groups[group_name])
+      ):
+        item = group_name
+        fraction = min((items_by_usefulness[item]) for item in self.logic.progress_item_groups[group_name])
+        fraction -= (len(self.logic.progress_item_groups[group_name]) - 1)
+
+      if fraction <= max_fraction:
+        available_items.add(item)
+
+    available_items -= DISALLOWED_RANDOM_STARTING_ITEMS
+    if not "Delivery Bag" in self.logic.currently_owned_items:
+      # Delivery bag is the only bag that can hold progression items, and we
+      # don't want to give a progression item if we don't have its bag since
+      # it's impossible to see the item until you get delivery bag in that case
+      available_items -= DELIVERY_BAG_ITEMS
+    if not self.options.get("keylunacy"):
+      available_items -= set(DUNGEON_PROGRESS_ITEMS)
+
+    # To avoid treasure charts overwhelming everything when enabled, group them so they have the same weight as any other item
+    if set(self.logic.treasure_chart_names).intersection(available_items):
+        available_items -= set(self.logic.treasure_chart_names)
+        available_items.add('Treasure Chart')
+    if set(self.logic.triforce_chart_names).intersection(available_items):
+        available_items -= set(self.logic.triforce_chart_names)
+        available_items.add('Triforce Chart')
+
+    # We need to sort before converting to lists because sets have per-process hash seeding
+    # and could otherwise lead to different randomization between processes with the same seed
+    return sorted(available_items)
+
+  def _save(self):
+    # This tweak is written in an idempotent way, so this should be ok to
+    # call a second time when this randomizer is enabled
+    tweaks.update_starting_gear(
+      self.rando,
+      self.options.get("starting_gear") + self.logic.expand_item_groups(self.random_starting_items)
+    )
+
+  def write_to_spoiler_log(self) -> str:
+    if self.random_starting_items:
+      return f"Random starting item: {', '.join(self.random_starting_items)}\n\n"
+    else:
+      return ""

--- a/randomizers/starting_item.py
+++ b/randomizers/starting_item.py
@@ -59,8 +59,13 @@ class StartingItemRandomizer(BaseRandomizer):
 
       # Sync the added items back to the other lists:
       self.logic.add_owned_item_or_item_group(selected)
-      self.rando.starting_items.extend(self.logic.expand_item_groups([selected]))
       self.random_starting_items.append(selected)
+      # Do *not* add it to the base starting items list, as it would mess up the
+      # hints since they'd start with a different set of starting items when
+      # demoting some progress items to nonprogress.
+      # Eg big octos with a starting boomerang would make the quiver foolish,
+      # which is (maybe?) confusing and would lead you to never check octos
+      # self.rando.starting_items.extend(self.logic.expand_item_groups([selected]))
 
     # Confirm that we opened at least one new check if we assigned an item
     if self.random_starting_items and len(self.logic.get_accessible_remaining_locations(for_progression=True)) <= len(initial_sphere_0_checks):

--- a/tweaks.py
+++ b/tweaks.py
@@ -1397,9 +1397,9 @@ def update_sword_mode_game_variable(self: WWRandomizer):
   else:
     raise Exception("Unknown sword mode: %s" % self.options.get("sword_mode"))
 
-def update_starting_gear(self: WWRandomizer):
-  starting_gear = self.options.get("starting_gear").copy()
-  
+def update_starting_gear(self: WWRandomizer, starting_gear: list[str]):
+  starting_gear = starting_gear.copy()
+
   # Changing starting magic doesn't work when done via our normal starting items initialization code, so we need to handle it specially.
   set_starting_magic(self, 16*starting_gear.count("Progressive Magic Meter"))
   while "Progressive Magic Meter" in starting_gear:

--- a/wwr_ui/options.py
+++ b/wwr_ui/options.py
@@ -176,6 +176,8 @@ OPTIONS = {
     "Amount of extra pieces of heart that you start with.",
   "starting_hcs":
     "Amount of extra heart containers that you start with.",
+  "num_random_starting_items":
+    "Amount of extra random progression items that you start with. They are guaranteed to unlock at least one additional check if nonzero",
   "remove_music":
     "Mutes all ingame music.",
   "randomize_enemies":

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -877,6 +877,46 @@
               </item>
              </layout>
             </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_random_starting_items">
+              <item>
+               <widget class="QLabel" name="label_for_num_random_starting_items">
+                <property name="text">
+                 <string>Additional Random Starting Items</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="num_random_starting_items">
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
+                <property name="maximum">
+                 <number>3</number>
+                </property>
+                <property name="value">
+                 <number>0</number>
+                </property>
+                <property name="displayIntegerBase">
+                 <number>10</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_random_starting_item">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
            </layout>
           </widget>
           <widget class="QWidget" name="tab_advanced">

--- a/wwr_ui/uic/ui_randomizer_window.py
+++ b/wwr_ui/uic/ui_randomizer_window.py
@@ -585,6 +585,29 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_4.addLayout(self.horizontalLayout_7)
 
+        self.horizontalLayout_random_starting_items = QHBoxLayout()
+        self.horizontalLayout_random_starting_items.setObjectName(u"horizontalLayout_random_starting_items")
+        self.label_for_num_random_starting_items = QLabel(self.tab_starting_items)
+        self.label_for_num_random_starting_items.setObjectName(u"label_for_num_random_starting_items")
+
+        self.horizontalLayout_random_starting_items.addWidget(self.label_for_num_random_starting_items)
+
+        self.num_random_starting_items = QSpinBox(self.tab_starting_items)
+        self.num_random_starting_items.setObjectName(u"num_random_starting_items")
+        self.num_random_starting_items.setLayoutDirection(Qt.LeftToRight)
+        self.num_random_starting_items.setMaximum(3)
+        self.num_random_starting_items.setValue(0)
+        self.num_random_starting_items.setDisplayIntegerBase(10)
+
+        self.horizontalLayout_random_starting_items.addWidget(self.num_random_starting_items)
+
+        self.horizontalSpacer_random_starting_item = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_random_starting_items.addItem(self.horizontalSpacer_random_starting_item)
+
+
+        self.verticalLayout_4.addLayout(self.horizontalLayout_random_starting_items)
+
         self.tabWidget.addTab(self.tab_starting_items, "")
         self.tab_advanced = QWidget()
         self.tab_advanced.setObjectName(u"tab_advanced")
@@ -1063,6 +1086,7 @@ class Ui_MainWindow(object):
         self.label_for_starting_hcs.setText(QCoreApplication.translate("MainWindow", u"Heart Containers", None))
         self.label_for_starting_pohs.setText(QCoreApplication.translate("MainWindow", u"Heart Pieces", None))
         self.current_health.setText(QCoreApplication.translate("MainWindow", u"Current Starting Health: 3 hearts", None))
+        self.label_for_num_random_starting_items.setText(QCoreApplication.translate("MainWindow", u"Additional Random Starting Items", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_starting_items), QCoreApplication.translate("MainWindow", u"Starting Items", None))
         self.groupBox_4.setTitle(QCoreApplication.translate("MainWindow", u"Required Bosses", None))
         self.required_bosses.setText(QCoreApplication.translate("MainWindow", u"Required Bosses Mode", None))


### PR DESCRIPTION
This randomizer allows adding up to 3 (completely arbitrary number, probably should change) random progression items to the starting gear of the seed, changing the locations that are accessible from the start of the game

Last year, the racing community experimented with some new options during the season 5 tournament. Some of these features have made it upstream (chest type matches contents, path/barren hints) but one that hasn't is the ability to start the game with additional progression items determined at random.
This is an RFC PR to gauge interest in integrating this in the official build. I'm mostly looking for design feedback and whether you'd be interested in having this feature (not necessarily with this implementation).

* The first commit is preparation to make it slightly easier to manage item groups (eg goddess pearls or tingle statues). This is the smallest refactor that allowed this implementation, but I have another larger version that reworks item groups that I can submit a PR for as well if desired
* The second and third commit are the base implementation
* The fourth commit is a behavior tweak for hints and progression spheres in the spoiler log to avoid the random starting items making other progression items useless for spheres and hints. This can be reverted, in which case the behavior of barren hints changes slightly (it can make items that are completely superseded by the random starting items barren, even if they can also be used to open useful locations)
* The fifth commit is a bugfix to charts handling, where a chart with multiple requirements (eg a triforce chart or a chart in a location with a gunboat, requiring bombs) could be chosen as the last item and make the assertion on new locations fail

<hr>

Testing-wise, i've run bulk generation counting the distribution of random starting items (for 10k seeds) and spot checked a few spoiler logs for those settings, as well as booted up seeds to check the starting inventory is as expected:
* default settings, with 1,2,3 random starting items
* season 5 racing settings with 1,2,3 random starting items
* allsanity with 1,2,3 random starting items
* season 5 settings without dungeons with 2 starting items (to test Farore's Pearl being progression without the other pearls)

For those familiar with the S5 implementation, these are currently the differences compared to that:
* Despite starting with these items, they aren't considered by the logic as starting items to determine which items are progression / CTMC chest types. For a classic example this means that starting with a random boomerang when octos are enabled still keeps a progressive quiver in logic, unlike what the previous build had
* The set of items received can be taken from any progression items with a few exceptions, not just a preset list (this is to make it work with more settings than just the S5/rsl settings)
* Taken all together, the random starting items have to open at least one additional sphere 0 check (for example, no starting with just a magic meter, but also not with just one leaf)