### PR TITLE
Fix how Mailbox locations are handled for hints

### DIFF
--- a/randomizers/entrances.py
+++ b/randomizers/entrances.py
@@ -1042,14 +1042,14 @@ class EntranceRandomizer(BaseRandomizer):
     
     loc_zone_name, _ = self.logic.split_location_name_by_zone(location_name)
     
+    if location_name == "Mailbox - Letter from Baito":
+      return {loc_zone_name} | self.get_all_zones_for_item_location("Earth Temple - Jalhalla Heart Container")
+    if location_name == "Mailbox - Letter from Orca":
+      return {loc_zone_name} | self.get_all_zones_for_item_location("Forbidden Woods - Kalle Demos Heart Container")
+    if location_name == "Mailbox - Letter from Aryll" or location_name == "Mailbox - Letter from Tingle":
+      return {loc_zone_name} | self.get_all_zones_for_item_location("Forsaken Fortress - Helmaroc King Heart Container")
+    
     if not self.is_item_location_behind_randomizable_entrance(location_name):
-      if location_name == "Mailbox - Letter from Baito":
-        return {loc_zone_name} | self.get_all_zones_for_item_location("Earth Temple - Jalhalla Heart Container")
-      if location_name == "Mailbox - Letter from Orca":
-        return {loc_zone_name} | self.get_all_zones_for_item_location("Forbidden Woods - Kalle Demos Heart Container")
-      if location_name == "Mailbox - Letter from Aryll" or location_name == "Mailbox - Letter from Tingle":
-        return {loc_zone_name} | self.get_all_zones_for_item_location("Forsaken Fortress - Helmaroc King Heart Container")
-      
       return {loc_zone_name}
     
     zone_exit = self.item_location_name_to_zone_exit[location_name]

--- a/randomizers/entrances.py
+++ b/randomizers/entrances.py
@@ -1023,6 +1023,8 @@ class EntranceRandomizer(BaseRandomizer):
     # Boss and miniboss locations are considered part of their respective dungeons, even when those
     # entrances are randomized.
     #
+    # A letter that is obtained from defeating a boss is considered part of the boss's dungeon.
+    #
     # Here are some examples:
     # - If the location is inside Dragon Roost Cavern, which is inside Forbidden Woods, which is
     #   at the Outset Island cave entrance, then the returned value is {"Dragon Roost Cavern",
@@ -1035,10 +1037,19 @@ class EntranceRandomizer(BaseRandomizer):
     # - If the location is inside the Star Island Cave, which is inside Wind Temple, which is at the
     #   Forsaken Fortress boss entrance, then the returned value is {"Wind Temple",
     #   "Forsaken Fortress"}.
+    # - If the location is Letter from Baito and Jalhalla is at the Southern Fairy Island entrance,
+    #   then the returned value is {"Mailbox", "Earth Temple", "Southern Fairy Island"}.
     
     loc_zone_name, _ = self.logic.split_location_name_by_zone(location_name)
     
     if not self.is_item_location_behind_randomizable_entrance(location_name):
+      if location_name == "Mailbox - Letter from Baito":
+        return {loc_zone_name} | self.get_all_zones_for_item_location("Earth Temple - Jalhalla Heart Container")
+      if location_name == "Mailbox - Letter from Orca":
+        return {loc_zone_name} | self.get_all_zones_for_item_location("Forbidden Woods - Kalle Demos Heart Container")
+      if location_name == "Mailbox - Letter from Aryll" or location_name == "Mailbox - Letter from Tingle":
+        return {loc_zone_name} | self.get_all_zones_for_item_location("Forsaken Fortress - Helmaroc King Heart Container")
+      
       return {loc_zone_name}
     
     zone_exit = self.item_location_name_to_zone_exit[location_name]

--- a/randomizers/hints.py
+++ b/randomizers/hints.py
@@ -731,14 +731,6 @@ class HintsRandomizer(BaseRandomizer):
     zones_with_useful_locations = set()
     for location_name in sorted(useful_locations):
       zones_with_useful_locations.update(self.rando.entrances.get_all_zones_for_item_location(location_name))
-      
-      # Include dungeon-related mail with its dungeon, in addition to Mailbox.
-      if location_name == "Mailbox - Letter from Baito":
-        zones_with_useful_locations.update(self.rando.entrances.get_all_zones_for_item_location("Earth Temple - Jalhalla Heart Container"))
-      if location_name == "Mailbox - Letter from Orca":
-        zones_with_useful_locations.update(self.rando.entrances.get_all_zones_for_item_location("Forbidden Woods - Kalle Demos Heart Container"))
-      if location_name == "Mailbox - Letter from Aryll" or location_name == "Mailbox - Letter from Tingle":
-        zones_with_useful_locations.update(self.rando.entrances.get_all_zones_for_item_location("Forsaken Fortress - Helmaroc King Heart Container"))
     
     # Now, we do the same with barren locations, identifying which zones have barren locations.
     zones_with_barren_locations = set()
@@ -748,14 +740,6 @@ class HintsRandomizer(BaseRandomizer):
         continue
       
       zones_with_barren_locations.update(self.rando.entrances.get_all_zones_for_item_location(location_name))
-      
-      # Include dungeon-related mail with its dungeon, in addition to Mailbox.
-      if location_name == "Mailbox - Letter from Baito":
-        zones_with_barren_locations.update(self.rando.entrances.get_all_zones_for_item_location("Earth Temple - Jalhalla Heart Container"))
-      if location_name == "Mailbox - Letter from Orca":
-        zones_with_barren_locations.update(self.rando.entrances.get_all_zones_for_item_location("Forbidden Woods - Kalle Demos Heart Container"))
-      if location_name == "Mailbox - Letter from Aryll" or location_name == "Mailbox - Letter from Tingle":
-        zones_with_barren_locations.update(self.rando.entrances.get_all_zones_for_item_location("Forsaken Fortress - Helmaroc King Heart Container"))
     
     # Finally, the difference between the zones with barren locations and the zones with useful locations gives us our
     # set of hintable barren zones.
@@ -782,15 +766,6 @@ class HintsRandomizer(BaseRandomizer):
     new_hintable_locations = []
     barrens = [hint.place for hint in hinted_barren_zones]
     for location_name in hintable_locations:
-      # Catch Mailbox cases.
-      if (
-          (location_name == "Mailbox - Letter from Baito" and "Earth Temple" in barrens)
-          or (location_name == "Mailbox - Letter from Orca" and "Forbidden Woods" in barrens)
-          or (location_name == "Mailbox - Letter from Aryll" and "Forsaken Fortress" in barrens)
-          or (location_name == "Mailbox - Letter from Tingle" and "Forsaken Fortress" in barrens)
-      ):
-        continue
-      
       entrance_zones = self.rando.entrances.get_all_zones_for_item_location(location_name)
       if not any(entrance_zone in barrens for entrance_zone in entrance_zones):
         new_hintable_locations.append(location_name)


### PR DESCRIPTION
I missed this in my [previous PR](https://github.com/LagoLunatic/wwrando/pull/356). Nested entrances were previously not being handled in `filter_out_hinted_barren_locations` for Mailbox locations.