### PR TITLE
Pack item groups when checking enemy requirements

### DIFF
--- a/logic/logic.py
+++ b/logic/logic.py
@@ -1325,7 +1325,7 @@ class Logic:
     biggest_combo = []
     for item_name, num in max_num_of_each_item_to_check.items():
       biggest_combo += [item_name]*num
-    biggest_combo = tuple(biggest_combo)
+    biggest_combo = tuple(self.pack_item_groups(biggest_combo))
     # print(f"Biggest item combo length: {len(biggest_combo)} items")
     # print(f"Biggest item combo: {biggest_combo}")
     


### PR DESCRIPTION
Adding/removing progress group items individually breaks the invariant that `Logic.unplaced_progress_items` always contains full groups.

In the original refactor of the logic for item groups I didn't test the enemy randomizer. 
When handling item combos the enemy randomizer breaks down groups into their individual components to add/remove them, which makes `unplaced_progress_items` contain all the individual items from the group instead of the group name.
Later when the item randomizer adds/removes all items to place dungeon items, it tries to remove the group name, instead of each individual item. Because the group name isn't in `unplaced_progress_items` (instead all the individual items are), `remove_owned_item_or_item_group` takes the branch that removes the whole group and tries to remove each individual item from `currently_owned_items` even though they aren't in the list, which raises.

Example permalink that this fixes: (reported in discord): `MS4xMC4wX2Q1MTRhMjIAR2F5RW5lbXlSYW5kbwDHPEDR0PxqVf0BAAAAAAAAAAAAAA==`

Fixes: 4f0f52b22661ddde9bb76e31f1fc366524a9a734