### PR TITLE
Github action for linux build

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,7 +35,7 @@ jobs:
             artifact: macos
             upload_path_suffix: '.zip'
           - name: Linux Build
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             architecture: x64
             artifact: linux
             upload_path_suffix: '/*'


### PR DESCRIPTION
As discussed with @wooferzfg in the context of introducing Linux support for the archipelago version of the randomizer in the following PR: https://github.com/tanjo3/wwrando/pull/4.

The current github action generated build doesn't work. I didn't deep dive into the cause of the error, but from what I see, the version of ubuntu used to make the build might be using old libraries which causes linux users using the Wayland display server to silently crash on start (at least when there's no console attached).
Take note that I haven't tested using the old X11 display server to see if I also get any kind of error.

The error I'm getting is the following:
```
./Wind Waker Randomizer: symbol lookup error: /tmp/_MEIjrDaOn/libQt6WaylandClient.so.6: undefined symbol: wl_proxy_marshal_flags
```
From what I've tested updating which version of ubuntu is used to make the build is enough to fix the problem.

In the PR for the archipelago build, I also updated the different build steps used since most are outdated. If you want, I can also update that for you. But take note that you'll need to clear your github action cache if I do so since the `setup-python` cache fail to work properly after updating the step.

Also, would it be possible to explain how to setup the SEED_KEY properly, since I don't really know what to do with that, and can't really test with it. I also ended up removing it from the archipelago build since we don't have the required details.