### PR TITLE
Import gclib relative to wwrando.py instead of current working directory

### DIFF
--- a/wwrando.py
+++ b/wwrando.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 
 import sys
-sys.path.insert(0, "./gclib")
+import os.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "gclib"))
 
 # Allow keyboard interrupts on the command line to instantly close the program.
 import signal


### PR DESCRIPTION
Executing the randomizer from source currently only works when the working directory is the root of the repository, with gclib being loaded from a path relative to the working directory of the shell. This changes the gclib load path to be relative to the `wwrando.py` file so that it's possible to execute the randomizer from different directories.
A similar method is already used in the assemble.py script here: https://github.com/LagoLunatic/wwrando/blob/ccb32a3cf1fcc398514f970039a775452217c1c5/asm/assemble.py#L14-L16

This might be linux-only (not sure how cwd works on other OS), and only shows up when running from source rather than release binaries (I tested that this change doesn't break a (linux) release binary though), so this is mostly for convenience when developing, but it would also be useful for the racetime.gg bot which can run multiple versions of the randomizer side-by-side

For example, on master when running from one directory up the tree it fails like this:
```shell
python wwrando/wwrando.py                                                                                                                                                                                                                                                                                                                                               
Traceback (most recent call last):
  File "<...>/wwrando/wwrando.py", line 294, in <module>
    run_with_ui(args)
  File "<...>/wwrando/wwrando.py", line 270, in run_with_ui
    from wwr_ui.randomizer_window import WWRandomizerWindow
  File "<...>/wwrando/wwr_ui/randomizer_window.py", line 5, in <module>
    from wwr_ui.uic.ui_randomizer_window import Ui_MainWindow
  File "<...>/wwrando/wwr_ui/uic/ui_randomizer_window.py", line 25, in <module>
    from wwr_ui.cosmetic_tab import CosmeticTab
  File "<...>/wwrando/wwr_ui/cosmetic_tab.py", line 20, in <module>
    import customizer
  File "<...>/wwrando/customizer.py", line 13, in <module>
    from gclib import fs_helpers as fs
ImportError: cannot import name 'fs_helpers' from 'gclib' (unknown location)
[1]    2494186 exit 1     python wwrando/wwrando.py
```