### PR TITLE
Very minor changes

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -1,6 +1,7 @@
-from dataclasses import fields, MISSING, Field, _recursive_repr, _FIELDS, _FIELD, asdict
+from dataclasses import fields, MISSING, Field, _FIELDS, _FIELD, asdict
 from typing import Any, Type, Optional
 import typing
+from reprlib import recursive_repr
 
 class Option(Field):
   type: Type
@@ -25,7 +26,7 @@ class Option(Field):
     self.hidden = hidden
     self.unbeatable = unbeatable
   
-  @_recursive_repr
+  @recursive_repr
   def __repr__(self):
       return ('Option('
               f'name={self.name!r},'

--- a/options/wwrando_options.py
+++ b/options/wwrando_options.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, KW_ONLY
+from dataclasses import dataclass
 from enum import StrEnum
 
 from options.base_options import BaseOptions, option

--- a/randomizers/extra_starting_items.py
+++ b/randomizers/extra_starting_items.py
@@ -1,11 +1,10 @@
-import typing
 from logic.item_types import DUNGEON_PROGRESS_ITEMS
 
 from randomizers.base_randomizer import BaseRandomizer
 import tweaks
 from options.wwrando_options import SwordMode
 
-DISALLOWED_RANDOM_STARTING_ITEMS = set([
+DISALLOWED_RANDOM_STARTING_ITEMS = {
   # There's a separate option for number of starting triforce shards that we'd need to mess with.
   "Triforce Shard 1",
   "Triforce Shard 2",
@@ -14,21 +13,16 @@ DISALLOWED_RANDOM_STARTING_ITEMS = set([
   "Triforce Shard 5",
   "Triforce Shard 6",
   "Triforce Shard 7",
-  "Triforce Shard 8",
+  "Triforce Shard 8"
   # Other items that you can't start with in the UI, but we allow anyway:
   # Treasure Charts and Triforce Charts: These seem to work fine to start with, even if not very fun
   # Tingle Statues: These seem to work fine
   # Boat's Sail, Wind Waker, Wind's Requiem: Mandatory starting items
   # Empty Bottle: Can only start with one Empty Bottle from the UI, but seems to work ok with more
   # DUNGEON_PROGRESS_ITEMS # Seem to work fine at least in keylunacy (enforced below)
-])
+}
 
-DELIVERY_BAG_ITEMS = set([
-  "Note to Mom",
-  "Maggie's Letter",
-  "Moblin's Letter",
-  "Cabana Deed",
-])
+DELIVERY_BAG_ITEMS = {"Note to Mom", "Maggie's Letter", "Moblin's Letter", "Cabana Deed"}
 
 class ExtraStartingItemsRandomizer(BaseRandomizer):
   def __init__(self, rando):


### PR DESCRIPTION
Started working on the next major version of multiworld, started a larger PR of stuff before cutting it back to some very simple stuff confirm on things before continuing.


Things I'm looking at doing to the main branch, but want confirmation before doing them.
Currently only `wwrando_options.Options` extends `BaseOptions`. I'm thinking of collapsing `BaseOptions` into `Options` to help consolidate some context.

In doing that I'd also swap from the current `all` from `BaseOptions` to instead be something more like
The Entrances/Exits with
```python
  def __repr__(self):
    return f"ZoneExit('{self.unique_name}')"
  
  all: ClassVar[dict[str, 'ZoneExit']] = {}
  
  def __post_init__(self):
    ZoneExit.all[self.unique_name] = self
```

Swap `if/elif` statements with `match/case` statements.
```python
# Connect signals to detect when the user changes each option.
if isinstance(widget, QAbstractButton):
  widget.clicked.connect(self.update_settings)
elif isinstance(widget, QComboBox):
  widget.currentIndexChanged.connect(self.update_settings)
  if option.choice_descriptions:
    widget.highlighted.connect(self.update_choice_highlighted_description)
elif isinstance(widget, QListView):
  pass
elif isinstance(widget, QSpinBox):
  widget.valueChanged.connect(self.update_settings)
else:
  raise Exception("Option widget is invalid: %s" % option.name)
# Instead
match widget:
  case QAbstractButton(): widget.clicked.connect(self.update_settings)
  case QComboBox(): 
    widget.currentIndexChanged.connect(self.update_settings)
    if option.choice_descriptions:
   # Rest of the direct cases/logic
   case _:
       raise Exception("Option widget is invalid: %s" % option.name)
```

Last one would be the lack of  `__init__.py` in a lot of folders that are treated more like modules. Feels a bit weird, so I was wondering the rational behind that.