### PR TITLE
asm: Support disassemble on non-windows

### DIFF
--- a/asm/disassemble.py
+++ b/asm/disassemble.py
@@ -2,6 +2,7 @@
 from subprocess import call
 from subprocess import DEVNULL
 import os
+import sys
 import re
 from io import BytesIO
 
@@ -15,8 +16,22 @@ def simplify_filename(filename):
     filename = filename[len("d_a_"):]
   return filename
 
+def devkitpath() -> str:
+  if sys.platform == "win32":
+    return r"C:\devkitPro\devkitPPC\bin"
+  else:
+    if "DEVKITPPC" not in os.environ:
+      raise Exception(r"Could not find devkitPPC. Path to devkitPPC should be in the DEVKITPPC env var")
+    return os.environ["DEVKITPPC"] + "/bin"
+
+def get_bin(name):
+  if sys.platform != "win32":
+    return os.path.join(devkitpath(), name)
+  return os.path.join(devkitpath(), name + ".exe")
+
+
 def disassemble_all_code(self):
-  if not os.path.isfile(r"C:\devkitPro\devkitPPC\bin\powerpc-eabi-objdump.exe"):
+  if not os.path.isfile(get_bin("powerpc-eabi-objdump")):
     raise Exception(r"Failed to disassemble code: Could not find devkitPPC. devkitPPC should be installed to: C:\devkitPro\devkitPPC")
   
   rels_arc = self.get_arc("files/RELS.arc")
@@ -110,7 +125,7 @@ def disassemble_all_code(self):
 
 def disassemble_file(bin_path, asm_path):
   command = [
-    r"C:\devkitPro\devkitPPC\bin\powerpc-eabi-objdump.exe",
+    get_bin("powerpc-eabi-objdump"),
     "--disassemble-zeroes",
     "-m", "powerpc",
     "-D",


### PR DESCRIPTION
Check for devkitppc using the environment variable on non-windows so `--disassemble` also works on unix platforms, in a similar fashion to how it is done in https://github.com/LagoLunatic/wwrando/blob/1efcfd2b93dcb3ce860b2d625cbb7d308c0853ea/asm/assemble.py#L12-L16, 
Unlike in asm/assemble, this file loaded on every invocation of the randomizer even without `--disassemble` so the check for devkitppc is only done when needed instead of when the file is loaded

Another option could be to factor this check into a common file that both assemble.py and disassemble.py import; I can update the PR and resend with that if that's a better option