### PR TITLE
Fix nonrandomized dungeon entrances with randomized boss entrances and required bosses mode

### DIFF
--- a/randomizers/entrances.py
+++ b/randomizers/entrances.py
@@ -331,7 +331,7 @@ class EntranceRandomizer(BaseRandomizer):
     
     self.safety_entrance = None
     self.banned_exits: list[ZoneExit] = []
-    self.islands_with_a_banned_dungeon: list[str] = []
+    self.islands_with_a_banned_dungeon: set[str] = set()
   
   def is_enabled(self) -> bool:
     return any([
@@ -360,6 +360,7 @@ class EntranceRandomizer(BaseRandomizer):
     return "Saving entrances..."
   
   def _randomize(self):
+    self.init_banned_exits()
     for relevant_entrances, relevant_exits in self.get_all_entrance_sets_to_be_randomized():
       self.randomize_one_set_of_entrances(relevant_entrances, relevant_exits)
     
@@ -404,6 +405,33 @@ class EntranceRandomizer(BaseRandomizer):
   
   
   #region Randomization
+  def init_banned_exits(self):
+    if self.options.required_bosses:
+      for zone_exit in BOSS_EXITS:
+        assert zone_exit.unique_name.endswith(" Boss Arena")
+        boss_name = zone_exit.unique_name[:-len(" Boss Arena")]
+        if boss_name in self.rando.boss_reqs.banned_bosses:
+          self.banned_exits.append(zone_exit)
+      for zone_exit in DUNGEON_EXITS:
+        dungeon_name = zone_exit.unique_name
+        if dungeon_name in self.rando.boss_reqs.banned_dungeons:
+          self.banned_exits.append(zone_exit)
+      for zone_exit in MINIBOSS_EXITS:
+        if zone_exit == ZoneExit.all["Master Sword Chamber"]:
+          # Hyrule cannot be chosen as a banned dungeon.
+          continue
+        assert zone_exit.unique_name.endswith(" Miniboss Arena")
+        dungeon_name = zone_exit.unique_name[:-len(" Miniboss Arena")]
+        if dungeon_name in self.rando.boss_reqs.banned_dungeons:
+          self.banned_exits.append(zone_exit)
+
+    if not self.options.randomize_dungeon_entrances:
+      # If dungeon entrances are not randomized, islands_with_a_banned_dungeon can be initialized 
+      # early since it's preset, and won't be updated later since we won't randomize the dungeon entrances
+      for en in DUNGEON_ENTRANCES:
+        if self.entrance_connections[en.entrance_name] in self.rando.boss_reqs.banned_dungeons:
+          self.islands_with_a_banned_dungeon.add(en.island_name)
+    
   def randomize_one_set_of_entrances(self, relevant_entrances: list[ZoneEntrance], relevant_exits: list[ZoneExit]):
     for zone_entrance in relevant_entrances:
       del self.done_entrances_to_exits[zone_entrance]
@@ -418,29 +446,6 @@ class EntranceRandomizer(BaseRandomizer):
       doing_caves = True
     
     self.rng.shuffle(relevant_entrances)
-    
-    self.banned_exits.clear()
-    if self.options.required_bosses:
-      for zone_exit in relevant_exits:
-        if zone_exit == ZoneExit.all["Master Sword Chamber"]:
-          # Hyrule cannot be chosen as a banned dungeon.
-          continue
-        if zone_exit in BOSS_EXITS:
-          assert zone_exit.unique_name.endswith(" Boss Arena")
-          boss_name = zone_exit.unique_name[:-len(" Boss Arena")]
-          if boss_name in self.rando.boss_reqs.banned_bosses:
-            self.banned_exits.append(zone_exit)
-        elif zone_exit in DUNGEON_EXITS:
-          dungeon_name = zone_exit.unique_name
-          if dungeon_name in self.rando.boss_reqs.banned_dungeons:
-            self.banned_exits.append(zone_exit)
-        elif zone_exit in MINIBOSS_EXITS:
-          assert zone_exit.unique_name.endswith(" Miniboss Arena")
-          dungeon_name = zone_exit.unique_name[:-len(" Miniboss Arena")]
-          if dungeon_name in self.rando.boss_reqs.banned_dungeons:
-            self.banned_exits.append(zone_exit)
-    
-    self.islands_with_a_banned_dungeon.clear()
     
     doing_progress_entrances_for_dungeons_and_caves_only_start = False
     if self.rando.dungeons_and_caves_only_start:
@@ -700,7 +705,7 @@ class EntranceRandomizer(BaseRandomizer):
         if zone_exit in DUNGEON_EXITS + BOSS_EXITS:
           # We only keep track of dungeon exits and boss exits, not miniboss exits.
           # Banned miniboss exits can share an island with required dungeons/bosses.
-          self.islands_with_a_banned_dungeon.append(zone_entrance.island_name)
+          self.islands_with_a_banned_dungeon.add(zone_entrance.island_name)
   
   def finalize_all_randomized_sets_of_entrances(self):
     non_terminal_exits = []

--- a/test/test_dry.py
+++ b/test/test_dry.py
@@ -39,6 +39,31 @@ def enable_all_progression_location_options(options: Options):
   options.progression_island_puzzles = True
   options.progression_dungeon_secrets = True
 
+def disable_all_progression_location_options(options: Options):
+  options.progression_dungeons = False
+  options.progression_great_fairies = False
+  options.progression_puzzle_secret_caves = False
+  options.progression_combat_secret_caves = False
+  options.progression_short_sidequests = False
+  options.progression_long_sidequests = False
+  options.progression_spoils_trading = False
+  options.progression_minigames = False
+  options.progression_free_gifts = False
+  options.progression_mail = False
+  options.progression_platforms_rafts = False
+  options.progression_submarines = False
+  options.progression_eye_reef_chests = False
+  options.progression_big_octos_gunboats = False
+  options.progression_triforce_charts = False
+  options.progression_treasure_charts = False
+  options.progression_expensive_purchases = False
+  options.progression_misc = False
+  options.progression_tingle_chests = False
+  options.progression_battlesquid = False
+  options.progression_savage_labyrinth = False
+  options.progression_island_puzzles = False
+  options.progression_dungeon_secrets = False
+
 def enable_all_options(options: Options):
   enable_all_progression_location_options(options)
   
@@ -142,6 +167,23 @@ def test_entrance_rando_enables():
   options.randomize_dungeon_entrances = True
   rando = dry_rando_with_options(options)
   assert rando.entrances.is_enabled()
+
+def test_regression_entrance_inner_rando():
+  # https://github.com/LagoLunatic/wwrando/pull/390
+  
+  options = Options()
+  disable_all_progression_location_options(options)
+  options.progression_dungeons = True
+  options.progression_dungeon_secrets = True
+  options.progression_free_gifts = True
+  options.progression_misc = True
+  
+  options.randomize_boss_entrances = True
+  options.required_bosses = True
+  options.num_required_bosses = 3
+  
+  rando = dry_rando_with_options(options)
+  rando.randomize_all()
 
 def test_trick_logic_checks():
   options = Options()


### PR DESCRIPTION
Currently, the combination of randomizing boss entrances but not dungeon entrances when using required bosses mode mostly fails to randomize successfully.
Example permalink: `MS4xMC4wXzM5NTRjZTkAQQAFEEAUAAH7AugSAAAgAIAAhCAAQAA=`.
A bulk test with these settings seems to have a 100% failure rate, but other values for number of required bosses (except 6) also fail to randomize most of the time

The first commit resolves the spurious `Not enough island entrances left to split entrances` in this case
The second commit resolves an underlying bug now made reachable where nonrandomized dungeons weren't tracked in `islands_with_a_banned_dungeon`, occasionally tripping the `not banned_island_names & required_island_names` assertion (same permalink, about 10% failure rate)
