### PR TITLE
Add "Hint Importance" option

### DIFF
--- a/options/wwrando_options.py
+++ b/options/wwrando_options.py
@@ -316,6 +316,11 @@ class Options(BaseOptions):
     default=False,
     description="When this option is selected, certain locations that are out of the way and time-consuming to complete will take precedence over normal location hints.",
   )
+  hint_importance: bool = option(
+    default=False,
+    description="When this option is selected, item and location hints will also indicate if the hinted item is required, possibly required, or not required.<br>"
+      "Only progress items will have these additions; non-progress items are trivially not required."
+  )
   #endregion
   
   #region Tweaks

--- a/randomizer.py
+++ b/randomizer.py
@@ -70,6 +70,7 @@ RNG_CHANGING_OPTIONS = [
   "num_item_hints",
   "cryptic_hints",
   "prioritize_remote_hints",
+  "hint_importance",
   "do_not_generate_spoiler_log",
 ]
 

--- a/randomizers/hints.py
+++ b/randomizers/hints.py
@@ -1,6 +1,6 @@
 import os
 from collections import Counter, deque
-from enum import Enum
+from enum import Flag
 import math
 import yaml
 
@@ -12,22 +12,29 @@ import tweaks
 from asm import patcher
 
 
-class HintType(Enum):
-  PATH = 0
-  BARREN = 1
-  ITEM = 2
-  LOCATION = 3
-  FIXED_LOCATION = 4
+class HintType(Flag):
+  PATH = 1
+  BARREN = 2
+  ITEM = 4
+  LOCATION = 8
+  FIXED_LOCATION = 16
+
+
+class ItemImportance(Flag):
+  REQUIRED = 1
+  POSSIBLY_REQUIRED = 2
+  NOT_REQUIRED = 4
 
 
 class Hint:
-  def __init__(self, type: HintType, place, reward=None):
+  def __init__(self, type: HintType, place, reward=None, importance=None):
     assert place is not None
     if type == HintType.BARREN: assert reward is None
     if type != HintType.BARREN: assert reward is not None
     self.type = type
     self.place = place
     self.reward = reward
+    self.importance = importance
   
   def formatted_place(self, is_cryptic: bool):
     if not is_cryptic:
@@ -56,18 +63,33 @@ class Hint:
       case _:
         raise NotImplementedError
   
+  def formatted_importance(self):
+    match self.importance:
+      case None:
+        return ""
+      case ItemImportance.REQUIRED:
+        return "required"
+      case ItemImportance.POSSIBLY_REQUIRED:
+        return "possibly required"
+      case ItemImportance.NOT_REQUIRED:
+        return "not required"
+      case _:
+        raise NotImplementedError
+  
   def __str__(self):
-    return "<HINT: %s, (%s, %s)>" % (
+    return "<HINT: %s, (%s, %s, %s)>" % (
       self.type.name,
       self.formatted_place(False),
       self.formatted_reward(False),
+      self.formatted_importance(),
     )
   
   def __repr__(self):
-    return "Hint(%s, %s, %s)" % (
+    return "Hint(%s, %s, %s, %s)" % (
       str(self.type),
       repr(self.place),
       repr(self.reward),
+      repr(self.importance),
     )
 
 
@@ -134,6 +156,10 @@ class HintsRandomizer(BaseRandomizer):
     
     self.cryptic_hints = self.options.cryptic_hints
     self.prioritize_remote_hints = self.options.prioritize_remote_hints
+    self.hint_importance = self.options.hint_importance
+    
+    self.path_locations: set[str] = None
+    self.barren_locations: set[str] = None
     
     self.floor_30_hint: Hint = None
     self.floor_50_hint: Hint = None
@@ -181,6 +207,9 @@ class HintsRandomizer(BaseRandomizer):
     self.path_logic = Logic(self.rando)
     self.path_logic_initial_state = self.path_logic.save_simulated_playthrough_state()
     
+    # Generate the hints that will be distributed over the hint placement options
+    hints = self.generate_hints()
+    
     self.floor_30_hint = self.generate_savage_labyrinth_hint("Outset Island - Savage Labyrinth - Floor 30")
     self.floor_50_hint = self.generate_savage_labyrinth_hint("Outset Island - Savage Labyrinth - Floor 50")
     
@@ -201,9 +230,6 @@ class HintsRandomizer(BaseRandomizer):
     hint_placement_options = list(self.hints_per_placement.keys())
     if self.total_num_hints == 0 or len(hint_placement_options) == 0:
       return
-    
-    # Generate the hints that will be distributed over the hint placement options
-    hints = self.generate_hints()
     
     # If there are less hints than placement options, duplicate the hints so that all selected
     # placement options have at least one hint.
@@ -253,7 +279,7 @@ class HintsRandomizer(BaseRandomizer):
         hint_index += 1
     
   def _save(self):
-    self.update_savage_labyrinth_hint_tablet(self.floor_30_hint, self.floor_50_hint)
+    self.update_savage_labyrinth_hint_tablet(self.floor_30_hint, self.floor_50_hint, self.hint_importance)
     
     if not any(self.check_item_can_be_hinted_at(item_name) for item_name in self.rando.all_randomized_progress_items):
       # See above.
@@ -261,7 +287,7 @@ class HintsRandomizer(BaseRandomizer):
     
     patcher.apply_patch(self.rando, "flexible_hint_locations")
     
-    self.update_big_octo_great_fairy_item_name_hint(self.octo_fairy_hint)
+    self.update_big_octo_great_fairy_item_name_hint(self.octo_fairy_hint, self.hint_importance)
     
     # Send the list of hints for each hint placement option to its respective distribution function.
     # Each hint placement option will handle how to place the hints in-game in their own way.
@@ -300,26 +326,46 @@ class HintsRandomizer(BaseRandomizer):
   
   
   #region Saving
-  def update_savage_labyrinth_hint_tablet(self, floor_30_hint: Hint, floor_50_hint: Hint):
+  def update_savage_labyrinth_hint_tablet(self, floor_30_hint: Hint, floor_50_hint: Hint, importance: bool):
     # Update the tablet on the first floor of savage labyrinth to give hints as to the items inside the labyrinth.
     
     floor_30_is_valid = self.check_item_can_be_hinted_at(floor_30_hint.reward)
     floor_50_is_valid = self.check_item_can_be_hinted_at(floor_50_hint.reward)
     
+    if importance:
+      floor_30_item_importance = floor_30_hint.formatted_importance()
+      if floor_30_hint.importance == ItemImportance.REQUIRED:
+        floor_30_item_importance = " (\\{1A 06 FF 00 00 02}%s\\{1A 06 FF 00 00 00})" % floor_30_item_importance
+      elif floor_30_hint.importance == ItemImportance.POSSIBLY_REQUIRED:
+        floor_30_item_importance = " (\\{1A 06 FF 00 00 04}%s\\{1A 06 FF 00 00 00})" % floor_30_item_importance
+      elif floor_30_hint.importance == ItemImportance.NOT_REQUIRED:
+        floor_30_item_importance = " (\\{1A 06 FF 00 00 07}%s\\{1A 06 FF 00 00 00})" % floor_30_item_importance
+      
+      floor_50_item_importance = floor_50_hint.formatted_importance()
+      if floor_50_hint.importance == ItemImportance.REQUIRED:
+        floor_50_item_importance = " (\\{1A 06 FF 00 00 02}%s\\{1A 06 FF 00 00 00})" % floor_50_item_importance
+      elif floor_50_hint.importance == ItemImportance.POSSIBLY_REQUIRED:
+        floor_50_item_importance = " (\\{1A 06 FF 00 00 04}%s\\{1A 06 FF 00 00 00})" % floor_50_item_importance
+      elif floor_50_hint.importance == ItemImportance.NOT_REQUIRED:
+        floor_50_item_importance = " (\\{1A 06 FF 00 00 07}%s\\{1A 06 FF 00 00 00})" % floor_50_item_importance
+    else:
+      floor_30_item_importance = ""
+      floor_50_item_importance = ""
+    
     if floor_30_is_valid and floor_50_is_valid:
-      hint = "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_30_hint.formatted_reward(self.cryptic_hints)
+      hint = "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s" % (floor_30_hint.formatted_reward(self.cryptic_hints), floor_30_item_importance)
       hint += " and "
-      hint += "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_50_hint.formatted_reward(self.cryptic_hints)
+      hint += "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s" % (floor_50_hint.formatted_reward(self.cryptic_hints), floor_50_item_importance)
       hint += " await"
     elif floor_30_is_valid:
-      hint = "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_30_hint.formatted_reward(self.cryptic_hints)
+      hint = "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s" % (floor_30_hint.formatted_reward(self.cryptic_hints), floor_30_item_importance)
       hint += " and "
       hint += "challenge"
       hint += " await"
     elif floor_50_is_valid:
       hint = "challenge"
       hint += " and "
-      hint += "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}" % floor_50_hint.formatted_reward(self.cryptic_hints)
+      hint += "\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s" % (floor_50_hint.formatted_reward(self.cryptic_hints), floor_50_item_importance)
       hint += " await"
     else:
       hint = "challenge"
@@ -330,21 +376,45 @@ class HintsRandomizer(BaseRandomizer):
     msg.string += "\\{1A 06 FF 00 00 00}Deep in the never-ending darkness, the way to %s." % hint
     msg.word_wrap_string(self.rando.bfn)
   
-  def update_big_octo_great_fairy_item_name_hint(self, hint: Hint):
+  def update_big_octo_great_fairy_item_name_hint(self, hint: Hint, importance: bool):
+    # The Octo Great Fairy must hint at a progress item
+    assert hint.importance is not None
+    
     msg = self.rando.bmg.messages_by_id[12015]
     msg.string = "\\{1A 06 FF 00 00 05}In \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 05}, you will find an item." % hint.formatted_place(self.cryptic_hints)
     msg.word_wrap_string(self.rando.bfn)
+    
     msg = self.rando.bmg.messages_by_id[12016]
-    msg.string = "\\{1A 06 FF 00 00 05}...\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 05}, which may help you on your quest." % tweaks.upper_first_letter(hint.formatted_reward(self.cryptic_hints))
+    reward = tweaks.upper_first_letter(hint.formatted_reward(self.cryptic_hints))
+    if importance:
+      copula = "is"
+      if hint.reward in ["Power Bracelets", "Iron Boots", "Bombs"]:
+        copula = "are"
+      
+      if hint.importance == ItemImportance.REQUIRED:
+        item_importance = "\\{1A 06 FF 00 00 02}%s\\{1A 06 FF 00 00 05}" % hint.formatted_importance()
+      elif hint.importance == ItemImportance.POSSIBLY_REQUIRED:
+        item_importance = "\\{1A 06 FF 00 00 04}%s\\{1A 06 FF 00 00 05}" % hint.formatted_importance()
+      elif hint.importance == ItemImportance.NOT_REQUIRED:
+        item_importance = "\\{1A 06 FF 00 00 07}%s\\{1A 06 FF 00 00 05}" % hint.formatted_importance()
+      
+      msg.string = "\\{1A 06 FF 00 00 05}...\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 05}, which %s %s in your quest." % (reward, copula, item_importance)
+    else:
+      msg.string = "\\{1A 06 FF 00 00 05}...\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 05}, which may help you on your quest." % reward
     msg.word_wrap_string(self.rando.bfn)
+    
     msg = self.rando.bmg.messages_by_id[12017]
-    msg.string = "\\{1A 06 FF 00 00 05}When you find you have need of such an item, you must journey to that place."
+    if importance and hint.importance == ItemImportance.NOT_REQUIRED:
+      # If the item is not required and the player is told so, change the post-hint message to be more appropriate.
+      msg.string = "\\{1A 06 FF 00 00 05}Though if you still desire such an item, you must journey to that place."
+    else:
+      msg.string = "\\{1A 06 FF 00 00 05}When you find you have need of such an item, you must journey to that place."
     msg.word_wrap_string(self.rando.bfn)
   
   def update_fishmen_hints(self):
     for fishman_island_number, hint in self.island_to_fishman_hint.items():
       hint_lines = []
-      hint_lines.append(HintsRandomizer.get_formatted_hint_text(hint, self.cryptic_hints, prefix="I've heard from my sources that ", suffix=".", delay=60))
+      hint_lines.append(HintsRandomizer.get_formatted_hint_text(hint, self.cryptic_hints, self.hint_importance, prefix="I've heard from my sources that ", suffix=".", delay=60))
       
       if self.cryptic_hints and (hint.type == HintType.ITEM or hint.type == HintType.LOCATION):
         hint_lines.append("Could be worth a try checking that place out. If you know where it is, of course.")
@@ -365,7 +435,7 @@ class HintsRandomizer(BaseRandomizer):
         hint_prefix = "\\{1A 05 01 01 03}Ho ho! To think that " if i == 0 else "and that "
         hint_suffix = "..." if i == len(hints_for_hoho) - 1 else ","
         
-        hint_lines.append(HintsRandomizer.get_formatted_hint_text(hint, self.cryptic_hints, prefix=hint_prefix, suffix=hint_suffix))
+        hint_lines.append(HintsRandomizer.get_formatted_hint_text(hint, self.cryptic_hints, self.hint_importance, prefix=hint_prefix, suffix=hint_suffix))
         
         if self.options.instant_text_boxes and i > 0:
           # If instant text mode is on, we need to reset the text speed to instant after the wait command messed it up.
@@ -426,7 +496,7 @@ class HintsRandomizer(BaseRandomizer):
       # Have no delay with KoRL text since he potentially has a lot of textboxes
       hint_prefix = "They say that " if i == 0 else "and that "
       hint_suffix = "." if i == len(hints) - 1 else ","
-      hint_lines.append(HintsRandomizer.get_formatted_hint_text(hint, self.cryptic_hints, prefix=hint_prefix, suffix=hint_suffix, delay=0))
+      hint_lines.append(HintsRandomizer.get_formatted_hint_text(hint, self.cryptic_hints, self.hint_importance, prefix=hint_prefix, suffix=hint_suffix, delay=0))
     
     for msg_id in (1502, 3443, 3444, 3445, 3446, 3447, 3448):
       msg = self.rando.bmg.messages_by_id[msg_id]
@@ -463,7 +533,7 @@ class HintsRandomizer(BaseRandomizer):
     return item_name
   
   @staticmethod
-  def get_formatted_hint_text(hint: Hint, cryptic: bool, prefix="They say that ", suffix=".", delay=30):
+  def get_formatted_hint_text(hint: Hint, cryptic: bool, importance: bool, prefix="They say that ", suffix=".", delay=30):
     place = hint.formatted_place(cryptic)
     if place == "Mailbox":
       place = "the mail"
@@ -473,6 +543,17 @@ class HintsRandomizer(BaseRandomizer):
       place = "the Forsaken Fortress sector"
     
     reward = hint.formatted_reward(cryptic)
+    
+    if importance:
+      item_importance = hint.formatted_importance()
+      if hint.importance == ItemImportance.REQUIRED:
+        item_importance = " (\\{1A 06 FF 00 00 02}%s\\{1A 06 FF 00 00 00})" % item_importance
+      elif hint.importance == ItemImportance.POSSIBLY_REQUIRED:
+        item_importance = " (\\{1A 06 FF 00 00 04}%s\\{1A 06 FF 00 00 00})" % item_importance
+      elif hint.importance == ItemImportance.NOT_REQUIRED:
+        item_importance = " (\\{1A 06 FF 00 00 07}%s\\{1A 06 FF 00 00 00})" % item_importance
+    else:
+      item_importance = ""
     
     if hint.type == HintType.PATH:
       place_preposition = "at"
@@ -494,16 +575,16 @@ class HintsRandomizer(BaseRandomizer):
       )
     elif hint.type == HintType.LOCATION:
       hint_string = (
-        "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00} rewards \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
-        % (prefix, place, reward, suffix)
+        "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00} rewards \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s%s"
+        % (prefix, place, reward, item_importance, suffix)
       )
     elif hint.type == HintType.ITEM:
       copula = "is"
       if reward in ["Power Bracelets", "Iron Boots", "Bombs"]:
         copula = "are"
       hint_string = (
-        "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00} %s located in \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
-        % (prefix, reward, copula, place, suffix)
+        "%s\\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s %s located in \\{1A 06 FF 00 00 01}%s\\{1A 06 FF 00 00 00}%s"
+        % (prefix, reward, item_importance, copula, place, suffix)
       )
     else:
       hint_string = ""
@@ -641,10 +722,6 @@ class HintsRandomizer(BaseRandomizer):
       if item_name not in self.logic.all_progress_items:
         continue
       
-      # Keys are only considered in key-lunacy.
-      if item_name.endswith(" Key") and not self.options.keylunacy:
-        continue
-      
       # Determine the item name for the given location.
       zone_name, specific_location_name = self.logic.split_location_name_by_zone(location_name)
       entrance_zone = self.rando.entrances.get_entrance_zone_for_item_location(location_name)
@@ -748,7 +825,7 @@ class HintsRandomizer(BaseRandomizer):
       useful_locations |= set(item_locations)
     
     # Subtracting the set of useful locations from the set of progress locations gives us our set of barren locations.
-    barren_locations = set(progress_locations) - useful_locations
+    self.barren_locations = set(progress_locations) - useful_locations
     
     # Since we hint at zones as barren, we next construct a set of zones which contain at least one useful item.
     zones_with_useful_locations = set()
@@ -757,7 +834,7 @@ class HintsRandomizer(BaseRandomizer):
     
     # Now, we do the same with barren locations, identifying which zones have barren locations.
     zones_with_barren_locations = set()
-    for location_name in sorted(barren_locations):
+    for location_name in sorted(self.barren_locations):
       # Don't consider locations hinted through remote location hints, as those are explicity barren.
       if location_name in hinted_remote_locations:
         continue
@@ -810,6 +887,23 @@ class HintsRandomizer(BaseRandomizer):
     
     return True
   
+  def get_importance_for_location(self, location_name):
+    if self.path_locations is None:
+      raise Exception("Path locations have not yet been initialized.")
+    if self.barren_locations is None:
+      raise Exception("Barren locations have not yet been initialized.")
+    
+    item_name = self.logic.done_item_locations[location_name]
+    if item_name not in self.logic.all_progress_items:
+      return None
+    
+    if location_name in self.path_locations:
+      return ItemImportance.REQUIRED
+    elif location_name in self.barren_locations:
+      return ItemImportance.NOT_REQUIRED
+    else:
+      return ItemImportance.POSSIBLY_REQUIRED
+  
   def check_is_legal_item_hint(self, location_name, progress_locations, previously_hinted_locations):
     item_name = self.logic.done_item_locations[location_name]
     
@@ -854,7 +948,9 @@ class HintsRandomizer(BaseRandomizer):
     item_name = self.logic.done_item_locations[location_name]
     entrance_zone = self.rando.entrances.get_entrance_zone_for_item_location(location_name)
     
-    item_hint = Hint(HintType.ITEM, entrance_zone, item_name)
+    item_importance = self.get_importance_for_location(location_name)
+    
+    item_hint = Hint(HintType.ITEM, entrance_zone, item_name, item_importance)
     
     return item_hint, location_name
   
@@ -899,8 +995,9 @@ class HintsRandomizer(BaseRandomizer):
     hintable_locations.remove(location_name)
     
     item_name = self.logic.done_item_locations[location_name]
+    item_importance = self.get_importance_for_location(location_name)
     
-    location_hint = Hint(HintType.LOCATION, location_name, item_name)
+    location_hint = Hint(HintType.LOCATION, location_name, item_name, item_importance)
     
     return location_hint, location_name
   
@@ -923,7 +1020,8 @@ class HintsRandomizer(BaseRandomizer):
   def generate_savage_labyrinth_hint(self, location_name):
     # Get an item hint for one of the two checks in Savage Labyrinth.
     item_name = self.logic.done_item_locations[location_name]
-    hint = Hint(HintType.FIXED_LOCATION, location_name, item_name)
+    item_importance = self.get_importance_for_location(location_name)
+    hint = Hint(HintType.FIXED_LOCATION, location_name, item_name, item_importance)
     return hint
   
   def generate_hints(self):
@@ -965,8 +1063,18 @@ class HintsRandomizer(BaseRandomizer):
     # small keys). Basically, we remove the item from that location and see if the path goal is still achievable. If
     # not, then we consider the item as required.
     required_locations_for_paths = {}
-    if self.max_path_hints > 0:
-      required_locations_for_paths = self.get_required_locations_for_paths()
+    required_locations_for_paths = self.get_required_locations_for_paths()
+    
+    # Flatten the list of path locations for reference for hint importance
+    self.path_locations = set()
+    for goal_name, path_locations in required_locations_for_paths.items():
+      for zone_name, entrance_zone, specific_location_name, item_name in path_locations:
+        self.path_locations.add("%s - %s" % (zone_name, specific_location_name))
+    
+    # Filter out the locations of dungeon keys as being path when key-lunacy is disabled
+    if not self.options.keylunacy:
+      for dungeon_name, dungeon_paths in required_locations_for_paths.items():
+        required_locations_for_paths[dungeon_name] = [item_tuple for item_tuple in dungeon_paths if not item_tuple[3].endswith(" Key")]
     
     # Generate path hints.
     # We hint at max `self.max_path_hints` zones at random.

--- a/randomizers/hints.py
+++ b/randomizers/hints.py
@@ -1,6 +1,6 @@
 import os
 from collections import Counter, deque
-from enum import Flag
+from enum import Enum
 import math
 import yaml
 
@@ -12,18 +12,18 @@ import tweaks
 from asm import patcher
 
 
-class HintType(Flag):
-  PATH = 1
-  BARREN = 2
-  ITEM = 4
-  LOCATION = 8
-  FIXED_LOCATION = 16
+class HintType(Enum):
+  PATH = 0
+  BARREN = 1
+  ITEM = 2
+  LOCATION = 3
+  FIXED_LOCATION = 4
 
 
-class ItemImportance(Flag):
-  REQUIRED = 1
-  POSSIBLY_REQUIRED = 2
-  NOT_REQUIRED = 4
+class ItemImportance(Enum):
+  REQUIRED = 0
+  POSSIBLY_REQUIRED = 1
+  NOT_REQUIRED = 2
 
 
 class Hint:

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -88,6 +88,7 @@ def enable_all_options(options: Options):
   options.num_item_hints = 15
   options.cryptic_hints = True
   options.prioritize_remote_hints = True
+  options.hint_importance = True
   
   options.do_not_generate_spoiler_log = False
   

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -1168,6 +1168,13 @@
                  </item>
                 </layout>
                </item>
+               <item row="6" column="2">
+                <widget class="QCheckBox" name="hint_importance">
+                 <property name="text">
+                  <string>Hint Importance</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>

--- a/wwr_ui/uic/ui_randomizer_window.py
+++ b/wwr_ui/uic/ui_randomizer_window.py
@@ -819,6 +819,11 @@ class Ui_MainWindow(object):
 
         self.gridLayout_7.addLayout(self.horizontalLayout_15, 5, 3, 1, 1)
 
+        self.hint_importance = QCheckBox(self.groupBox_5)
+        self.hint_importance.setObjectName(u"hint_importance")
+
+        self.gridLayout_7.addWidget(self.hint_importance, 6, 2, 1, 1)
+
 
         self.verticalLayout_8.addWidget(self.groupBox_5)
 
@@ -1121,6 +1126,7 @@ class Ui_MainWindow(object):
         self.label_for_num_location_hints.setText(QCoreApplication.translate("MainWindow", u"Location Hints", None))
         self.label_for_num_item_hints.setText(QCoreApplication.translate("MainWindow", u"Item Hints", None))
         self.label_for_num_path_hints.setText(QCoreApplication.translate("MainWindow", u"Path Hints", None))
+        self.hint_importance.setText(QCoreApplication.translate("MainWindow", u"Hint Importance", None))
         self.groupBox_6.setTitle(QCoreApplication.translate("MainWindow", u"Additional Advanced Options", None))
         self.do_not_generate_spoiler_log.setText(QCoreApplication.translate("MainWindow", u"Do Not Generate Spoiler Log", None))
         self.dry_run.setText(QCoreApplication.translate("MainWindow", u"Dry Run", None))


### PR DESCRIPTION
This PR adds a new hint option called "Hint Importance". When this setting is enabled, item and location hints are slightly modified to include information if the reward is required, possibly required, or not required. This setting has been added somewhat recently to other randomizers (Majora's Mask and Twilight Princess randomizers, for instance). I'm using the naming convention from the OoTMM cross randomizer. This is an optional setting, disabled by default.

If this setting is disabled, then hints are written as before. If this setting is enabled, generated item and location hints may be modified with this importance information. This information is already determined when generating path and barren hints, so no additional logic processing needs to be done.

An item that is **required** is an item that is required for at least one of the path goals in the randomized seed. An item that is **not required** is an item that the player does not need to collect to complete all the path goals. An item that is **possibly required** is an item that may be used to accomplish a path goal, but there may be a different path to that goal that does not use that item. This follows from the path and barren logic of hints already in the randomizer.

Below are two examples of item hints (on the King of Red Lions), showing examples of items being hinted as possibly required and not required:
<img src="https://github.com/LagoLunatic/wwrando/assets/4733098/cb4294b9-f0c2-4543-b3b6-fa13da834b5d" width="400" />  
<img src="https://github.com/LagoLunatic/wwrando/assets/4733098/fc4aa92e-6c60-46cb-bc17-e8784b6981b0" width="400" />
In the second example, the hinted Tingle statue is not required because the item on the Ankle check (which is the only check directly locked behind Tingle statues) is also not required. However, the Ankle check is a logical location in the seed (i.e., the Miscellaneous category of locations is on). Non-progress items do not include importance information, even with the hint importance options turned on, because they are trivially non-required. A quick benefit of the setting is that if sunken treasure from Triforce Charts and cryptic hints are _off_, the reader can quickly tell the difference between a hinted Triforce **_Shard_** and Triforce _**Chart**_ since a hint for a shard will note that it is required and a hint for a chart will contain no additional information. This is a frequent misread for runners. Additionally, note the color highlighting of the hint importance text.

Here is an example of a location hint for a required item:
<img src="https://github.com/LagoLunatic/wwrando/assets/4733098/7dea24e1-4b9b-4a22-8854-2926ff0ff5f6" width="400" />

Since the Savage Labyrinth and Octo Fairy hints are item and location hints, respectively, they, too, are affected by the setting. The Savage Labyrinth stone tablet follows a similar syntax for other location hints:
<img src="https://github.com/LagoLunatic/wwrando/assets/4733098/84d5d490-2d91-4837-b7a6-ab2960731ada" width="400" />
The colors for the tablet text are different, so I couldn't quite get the same palette, but the highlighting is the important part (for ease of readability), not necessarily the exact colors.

The Octo Fairy's text is modified to incorporate the importance, as shown below:
<img src="https://github.com/LagoLunatic/wwrando/assets/4733098/dbb03da1-5152-400c-b0a0-a80405591684" width="400" />
The original text (i.e., with the hint importance option off) would say, "A piece of the power of the gods, which may help you on your quest." If hint importance is on and the hinted item is not required, the following text box would say, "Though if you still desire such an item, you must journey to that place." Otherwise, the original text of "When you find you have need of such an item, you must journey to that place." is used. I made this change since saying that an item is not required and then saying "when you need the item..." sounds awkward.

Some additional implementation notes: since the Savage Labyrinth and Octo Fairy require the hint importance information, and this information is calculated in the call to `generate_hints()` in `randomizers/hints.py,` I've moved this call to before either the Savage Labyrinth and Octo Fairy hints are generated. This doesn't affect hint generation. Also, dungeon keys are conventionally not considered path items when key-lunacy is disabled since getting a path hint for the DRC Small Key in the first room would feel pretty bad (as an example). However, if a location containing a dungeon key is selected for a location hint, we don't want to say that the key is not required when it obviously is. As such, the filter for dungeon keys in non-key-lunacy seeds is moved to after `get_required_locations_for_paths()` and all path locations (including keys) have been recorded in `self.path_locations`. Finally, since remote location hints are necessarily determined before path or barren hints, the setting of the importance of these items is deferred until both path and barren hints are generated.