### PR TITLE
Set defeating Wizzrobe at range with Hookshot to Precise 1

### DIFF
--- a/logic/macros.txt
+++ b/logic/macros.txt
@@ -876,7 +876,8 @@ Can Defeat Wizzrobes:
   | Skull Hammer
 Can Defeat Wizzrobes at Range:
   Hero's Bow
-  | Hookshot
+  | (Hookshot & Precise 1)
+  # Precise: The Hookshot requires twice as many hits as the Hero's Bow and is slower, making fighting Wizzrobes at range rather challenging.
 Can Defeat Armos:
   Hero's Sword
   | Hero's Bow


### PR DESCRIPTION
I've heard from casual and competitive runners alike that defeating Wizzrobes at range with just the Hookshot is probably too challenging to be in the base logic. In particular, for Pawprint Isle - Wizzrobe Cave and Flight Control Platform - Submarine, defeating the Wizzrobes with Hookshot while constantly assaulted by other enemies is too frustrating. So, I suggest moving this to Precise 1, at the minimum.

This PR sets the `Can Defeat Wizzrobes at Range` macro to be `Hero's Bow | (Hookshot & Precise 1)` rather than `Hero's Bow | Hookshot`.