### PR TITLE
Add tournament winners to seed name generation

### DIFF
--- a/seedgen/names.txt
+++ b/seedgen/names.txt
@@ -113,3 +113,8 @@ din
 farore
 nayru
 jabun
+woofer
+jarheadHME
+jwiste
+advocate
+rickSchmidty


### PR DESCRIPTION
This PR adds the names of the WWR Racing Discord's seasonal tournament to the list of names possibly used for seed names. Each runner has given their consent to be included. The winners of the tournaments so far have been:
- Seasons 1 and 2: woofer
- Season 3: JarheadHME
- Season 4: jwiste
- Seasons 5 and 6: Advocate
- Season 7: Rick Schmidty