### PR TITLE
Fix bug in path hint calculation

### DIFF
--- a/randomizers/hints.py
+++ b/randomizers/hints.py
@@ -665,7 +665,10 @@ class HintsRandomizer(BaseRandomizer):
     while self.path_logic.unplaced_progress_items:
       progress_items_in_this_sphere = {}
       
-      accessible_locations = self.path_logic.get_accessible_remaining_locations(for_progression=False)
+      # Only consider progress locations.
+      accessible_locations = self.path_logic.get_accessible_remaining_locations(for_progression=True)
+      accessible_locations = list(set(accessible_locations) - set(self.rando.boss_reqs.banned_locations))
+      
       locations_in_this_sphere = [
         loc for loc in accessible_locations
         if loc not in previously_accessible_locations
@@ -697,9 +700,6 @@ class HintsRandomizer(BaseRandomizer):
           previously_accessible_locations += newly_accessible_small_key_locations
           continue # Redo this loop iteration with the small key locations no longer being considered 'remaining'.
       
-      
-      # Hide duplicated progression items (e.g. Empty Bottles) when they are placed in non-progression locations to avoid confusion and inconsistency.
-      locations_in_this_sphere = self.path_logic.filter_locations_for_progression(locations_in_this_sphere)
       
       for location_name in locations_in_this_sphere:
         item_name = self.logic.done_item_locations[location_name]


### PR DESCRIPTION
This PR fixes a bug in path hint calculation.

To determine if an item is path, the randomizer plays through the seed, removing that item from the playthrough, and then determining if the path goal is still reachable. If it is, then that item must not be required, and therefore not path. Otherwise, it must be a path item. However, during this playthrough, the randomizer will also consider locations in non-required dungeons when required bosses mode is on. So, if a duplicate copy of an item is accessible there, then the copy that is in logic may no longer be considered a path item, despite it being required for the playthrough. This only arises for items like Empty Bottles whose copies may be placed in non-progress locations.

Also, the filter for progress locations used to be done at the end of each sphere. We've moved it up in the loop. This way, the randomizer doesn't need to determine the accessibility of non-progress locations for each sphere, as these should not be considered for path logic in the first place.