### PR TITLE
Add option to place progress items on boss locations

### DIFF
--- a/options/wwrando_options.py
+++ b/options/wwrando_options.py
@@ -171,6 +171,10 @@ class Options(BaseOptions):
     description="Select the number of randomly-chosen bosses that are required in Required Bosses Mode.<br>"
       "The door to Puppet Ganon will not unlock until you've defeated all of these bosses. Nothing in dungeons for other bosses will ever be required.",
   )
+  prioritize_required_bosses: bool = option(
+    default=False,
+    description="Guarantees that each required boss's Heart Container location will contain a progress item.",
+  )
   chest_type_matches_contents: bool = option(
     default=False,
     description="Changes the chest type to reflect its contents. A metal chest has a progress item, a wooden chest has a non-progress item or a consumable, and a green chest has a potentially required dungeon key.",

--- a/randomizers/items.py
+++ b/randomizers/items.py
@@ -51,6 +51,9 @@ class ItemRandomizer(BaseRandomizer):
         print(location_name)
     
     self.randomize_consumable_items()
+    
+    if self.options.required_bosses and self.options.prioritize_required_bosses:
+      self.ensure_boss_locations_have_progress_items()
   
   def _save(self):
     for location_name, item_name in self.logic.done_item_locations.items():
@@ -191,6 +194,64 @@ class ItemRandomizer(BaseRandomizer):
     location_name = self.rng.choice(possible_locations)
     self.logic.set_prerandomization_item_location(location_name, item_name)
   
+  def check_is_swappable_item_for_boss_location(self, location_name, item_name, boss_location_name, boss_item_name):
+    # Don't swap with another required boss location.
+    if location_name in self.rando.boss_reqs.required_boss_item_locations:
+      return False
+    
+    # Only swap progress items onto a boss location.
+    if item_name not in self.rando.all_randomized_progress_items:
+      return False
+    
+    # Don't swap dungeon items onto a boss location.
+    if self.logic.is_dungeon_item(item_name):
+      return False
+    
+    # Check if both items are valid in swapped locations.
+    if not self.logic.check_item_valid_in_location(item_name, boss_location_name):
+      return False
+    if not self.logic.check_item_valid_in_location(boss_item_name, location_name):
+      return False
+    
+    return True
+  
+  def ensure_boss_locations_have_progress_items(self):
+    for boss_location_name in self.rando.boss_reqs.required_boss_item_locations:
+      boss_item_name = self.logic.done_item_locations.get(boss_location_name)
+      if boss_item_name is None or boss_item_name in self.rando.all_randomized_progress_items:
+        # Boss location already has a progress item or hasn't been filled yet.
+        continue
+      
+      # Determine which locations have items that are swappable with the boss item.
+      candidate_swap_locations = [
+        (location_name, item_name)
+        for location_name, item_name in self.logic.done_item_locations.items()
+        if self.check_is_swappable_item_for_boss_location(
+          location_name, item_name, boss_location_name, boss_item_name
+        )
+      ]
+      self.rng.shuffle(candidate_swap_locations)
+      
+      swapped = False
+      for candidate_location_name, candidate_item_name in candidate_swap_locations:
+        # Swap items between the two locations.
+        self.logic.done_item_locations[boss_location_name] = candidate_item_name
+        self.logic.done_item_locations[candidate_location_name] = boss_item_name
+        
+        try:
+          # Verify the game is still beatable.
+          self.calculate_playthrough_progression_spheres()
+          swapped = True
+          break
+        except Exception:
+          # If not, revert the swap and try another candidate location.
+          self.logic.done_item_locations[boss_location_name] = boss_item_name
+          self.logic.done_item_locations[candidate_location_name] = candidate_item_name
+      
+      # If no valid swap was found, raise an Exception.
+      if not swapped:
+        raise Exception(f"Unable to place progress item at boss location: {boss_location_name}")
+  
   def randomize_progression_items_forward_fill(self):
     accessible_undone_locations = self.logic.get_accessible_remaining_locations(for_progression=True)
     if self.logic.unplaced_progress_items and len(accessible_undone_locations) == 0:
@@ -318,6 +379,15 @@ class ItemRandomizer(BaseRandomizer):
         ]
         if possible_locations_without_sunken_treasures:
           possible_locations = possible_locations_without_sunken_treasures
+      
+      # If required bosses are prioritized to have progress items, force placement on boss locations.
+      if self.options.required_bosses and self.options.prioritize_required_bosses and not self.logic.is_dungeon_item(item_name):
+        boss_locations = [
+          location_name for location_name in self.rando.boss_reqs.required_boss_item_locations
+          if location_name in possible_locations and location_name in self.logic.remaining_item_locations
+        ]
+        if boss_locations:
+          possible_locations = boss_locations
       
       # We weight it so newly accessible locations are more likely to be chosen.
       # This way there is still a good chance it will not choose a new location.

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -74,6 +74,7 @@ def enable_all_options(options: Options):
   
   options.required_bosses = True
   options.num_required_bosses = 4
+  options.prioritize_required_bosses = True
   
   options.chest_type_matches_contents = True
   

--- a/wwr_ui/randomizer_window.py
+++ b/wwr_ui/randomizer_window.py
@@ -658,6 +658,7 @@ class WWRandomizerWindow(QMainWindow):
     
     if not options.required_bosses:
       should_enable_options["num_required_bosses"] = False
+      should_enable_options["prioritize_required_bosses"] = False
     
     if options.num_location_hints == 0:
       should_enable_options["prioritize_remote_hints"] = False

--- a/wwr_ui/randomizer_window.ui
+++ b/wwr_ui/randomizer_window.ui
@@ -901,7 +901,11 @@
                 </layout>
                </item>
                <item row="0" column="2">
-                <widget class="QWidget" name="widget_4" native="true"/>
+                <widget class="QCheckBox" name="prioritize_required_bosses">
+                 <property name="text">
+                  <string>Prioritize Required Bosses</string>
+                 </property>
+                </widget>
                </item>
                <item row="0" column="3">
                 <widget class="QWidget" name="widget_5" native="true"/>
@@ -1415,6 +1419,7 @@
   <tabstop>num_extra_starting_items</tabstop>
   <tabstop>required_bosses</tabstop>
   <tabstop>num_required_bosses</tabstop>
+  <tabstop>prioritize_required_bosses</tabstop>
   <tabstop>hero_mode</tabstop>
   <tabstop>logic_obscurity</tabstop>
   <tabstop>logic_precision</tabstop>

--- a/wwr_ui/uic/ui_randomizer_window.py
+++ b/wwr_ui/uic/ui_randomizer_window.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'randomizer_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.3
+## Created by: Qt User Interface Compiler version 6.8.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -623,10 +623,10 @@ class Ui_MainWindow(object):
 
         self.gridLayout_6.addLayout(self.horizontalLayout_8, 0, 1, 1, 1)
 
-        self.widget_4 = QWidget(self.groupBox_4)
-        self.widget_4.setObjectName(u"widget_4")
+        self.prioritize_required_bosses = QCheckBox(self.groupBox_4)
+        self.prioritize_required_bosses.setObjectName(u"prioritize_required_bosses")
 
-        self.gridLayout_6.addWidget(self.widget_4, 0, 2, 1, 1)
+        self.gridLayout_6.addWidget(self.prioritize_required_bosses, 0, 2, 1, 1)
 
         self.widget_5 = QWidget(self.groupBox_4)
         self.widget_5.setObjectName(u"widget_5")
@@ -997,7 +997,8 @@ class Ui_MainWindow(object):
         QWidget.setTabOrder(self.starting_pohs, self.num_extra_starting_items)
         QWidget.setTabOrder(self.num_extra_starting_items, self.required_bosses)
         QWidget.setTabOrder(self.required_bosses, self.num_required_bosses)
-        QWidget.setTabOrder(self.num_required_bosses, self.hero_mode)
+        QWidget.setTabOrder(self.num_required_bosses, self.prioritize_required_bosses)
+        QWidget.setTabOrder(self.prioritize_required_bosses, self.hero_mode)
         QWidget.setTabOrder(self.hero_mode, self.logic_obscurity)
         QWidget.setTabOrder(self.logic_obscurity, self.logic_precision)
         QWidget.setTabOrder(self.logic_precision, self.hoho_hints)
@@ -1102,6 +1103,7 @@ class Ui_MainWindow(object):
         self.groupBox_4.setTitle(QCoreApplication.translate("MainWindow", u"Required Bosses", None))
         self.required_bosses.setText(QCoreApplication.translate("MainWindow", u"Required Bosses Mode", None))
         self.label_for_num_required_bosses.setText(QCoreApplication.translate("MainWindow", u"Number of Required Bosses", None))
+        self.prioritize_required_bosses.setText(QCoreApplication.translate("MainWindow", u"Prioritize Required Bosses", None))
         self.groupBox_9.setTitle(QCoreApplication.translate("MainWindow", u"Difficulty Options", None))
         self.hero_mode.setText(QCoreApplication.translate("MainWindow", u"Hero Mode", None))
         self.label_for_logic_obscurity.setText(QCoreApplication.translate("MainWindow", u"Obscure Tricks Required", None))

--- a/wwr_ui/uic/ui_randomizer_window.py
+++ b/wwr_ui/uic/ui_randomizer_window.py
@@ -623,10 +623,10 @@ class Ui_MainWindow(object):
 
         self.gridLayout_6.addLayout(self.horizontalLayout_8, 0, 1, 1, 1)
 
-        self.widget_4 = QWidget(self.groupBox_4)
-        self.widget_4.setObjectName(u"widget_4")
+        self.prioritize_required_bosses = QCheckBox(self.groupBox_4)
+        self.prioritize_required_bosses.setObjectName(u"prioritize_required_bosses")
 
-        self.gridLayout_6.addWidget(self.widget_4, 0, 2, 1, 1)
+        self.gridLayout_6.addWidget(self.prioritize_required_bosses, 0, 2, 1, 1)
 
         self.widget_5 = QWidget(self.groupBox_4)
         self.widget_5.setObjectName(u"widget_5")
@@ -997,7 +997,8 @@ class Ui_MainWindow(object):
         QWidget.setTabOrder(self.starting_pohs, self.num_extra_starting_items)
         QWidget.setTabOrder(self.num_extra_starting_items, self.required_bosses)
         QWidget.setTabOrder(self.required_bosses, self.num_required_bosses)
-        QWidget.setTabOrder(self.num_required_bosses, self.hero_mode)
+        QWidget.setTabOrder(self.num_required_bosses, self.prioritize_required_bosses)
+        QWidget.setTabOrder(self.prioritize_required_bosses, self.hero_mode)
         QWidget.setTabOrder(self.hero_mode, self.logic_obscurity)
         QWidget.setTabOrder(self.logic_obscurity, self.logic_precision)
         QWidget.setTabOrder(self.logic_precision, self.hoho_hints)
@@ -1102,6 +1103,7 @@ class Ui_MainWindow(object):
         self.groupBox_4.setTitle(QCoreApplication.translate("MainWindow", u"Required Bosses", None))
         self.required_bosses.setText(QCoreApplication.translate("MainWindow", u"Required Bosses Mode", None))
         self.label_for_num_required_bosses.setText(QCoreApplication.translate("MainWindow", u"Number of Required Bosses", None))
+        self.prioritize_required_bosses.setText(QCoreApplication.translate("MainWindow", u"Prioritize Required Bosses", None))
         self.groupBox_9.setTitle(QCoreApplication.translate("MainWindow", u"Difficulty Options", None))
         self.hero_mode.setText(QCoreApplication.translate("MainWindow", u"Hero Mode", None))
         self.label_for_logic_obscurity.setText(QCoreApplication.translate("MainWindow", u"Obscure Tricks Required", None))


### PR DESCRIPTION
This PR adds a new option, `prioritize_required_bosses`, that places progress items at the required bosses' locations (i.e., their Heart Container locations). This option can only be enabled if Required Bosses Mode (RBM) is on. When playing with RBM, feedback from some players was that defeating the required bosses didn't feel as rewarding as it used to when they guaranteed dropped Triforce Shards. Rather than reverting to the original implementation, this option places progress items on required bosses. The item is, of course, not guaranteed to be useful to beat the seed, but it should feel more rewarding than getting a Red Rupee or Joy Necklace from defeating bosses.

This implementation has two parts. First, during forward fill, if a boss location is made accessible, a progress item must be placed on it. However, this does not guarantee all bosses will have progress items, as some bosses are made accessible after all progress items have been placed. So, after all locations are filled, a pass through all boss locations without a progress item is done. For each boss item, we attempt to swap it with a placed progress item and verify the seed's validity.

If no valid swaps are possible, an error is thrown. I ran a bulk test of 100 seeds with default settings and another 100 with all options, and didnt run into any generation failures. I also checked that the boss locations actually had a progress item. For this reason, I didn't add any additional tests for this option.