### PR TITLE
Use permalink as seed string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Changes:
 * The spoiler log now includes hints and Required Bosses Mode's required dungeons.
 * Added an option to enable the game's "Switch" L-targeting mode from the randomizer's settings so that you don't have to enable it from within the game's options menu after starting a new save file.
 * Added an advanced "Dry Run" option which generates just the logs for a seed, without the playable ISO. Because no ISO is created, this option can be used to check a seed's item locations on a PC where you don't have a vanilla Wind Waker ISO on hand.
+* Changing any option that affects the permalink now also changes item placement for the same seed name. Previously only the seed name and a handful of hint-related options re-rolled placement.
 
 Bug fixes:
 * Fixed a bug in Key-Lunacy where small keys were less likely to appear early in the seed, causing dungeons to tend to become accessible late in the seed.

--- a/randomizer.py
+++ b/randomizer.py
@@ -58,24 +58,6 @@ from randomizers.extra_starting_items import ExtraStartingItemsRandomizer
 
 from version import VERSION, VERSION_WITHOUT_COMMIT
 
-# The below are options that could be used to cheat in races.
-# They do not naturally change algorithmic item distribution, but do change the availability of information on item distribution.
-# To prevent this possibility, we change the RNG seed itself for each one of these options that is selected.
-# This ensures that item distribution is different between people with the same seed but different hints, for example.
-RNG_CHANGING_OPTIONS = [
-  "fishmen_hints",
-  "hoho_hints",
-  "korl_hints",
-  "num_path_hints",
-  "num_barren_hints",
-  "num_location_hints",
-  "num_item_hints",
-  "cryptic_hints",
-  "prioritize_remote_hints",
-  "hint_importance",
-  "do_not_generate_spoiler_log",
-]
-
 class TooFewProgressionLocationsError(Exception): pass
 class InvalidCleanISOError(Exception): pass
 class PermalinkWrongVersionError(Exception): pass
@@ -124,7 +106,7 @@ class WWRandomizer:
     if cmd_line_args.test:
       self.test_room_args = cmd_line_args.test
     
-    seed_string = self.seed
+    seed_string = self.permalink
     if self.options.do_not_generate_spoiler_log:
       seed_string += SEED_KEY
     
@@ -950,13 +932,6 @@ class WWRandomizer:
   def get_new_rng(self):
     rng = Random()
     rng.seed(self.integer_seed)
-    
-    # Further change the RNG based on which RNG-changing options are enabled
-    for i, option in enumerate(RNG_CHANGING_OPTIONS):
-      value = self.options[option]
-      for j in range(1, 100 + i):
-        rng.getrandbits(value + 20 * i + j)
-    
     return rng
   
   def weighted_choice(self, rng: Random, seq: list[T], weight_conditions: list[tuple[int, Callable[[T], bool]]]) -> T:

--- a/randomizer.py
+++ b/randomizer.py
@@ -80,6 +80,12 @@ class WWRandomizer:
     self.options = options
     self.seed = self.sanitize_seed(seed)
     self.permalink = self.encode_permalink(self.seed, self.options)
+    
+    seed_string = self.permalink
+    if self.options.do_not_generate_spoiler_log:
+      seed_string += SEED_KEY
+    
+    self.integer_seed = self.convert_string_to_integer_md5(seed_string)
     self.seed_hash = self.get_seed_hash()
     
     if cmd_line_args is None:
@@ -105,12 +111,6 @@ class WWRandomizer:
     self.test_room_args = None
     if cmd_line_args.test:
       self.test_room_args = cmd_line_args.test
-    
-    seed_string = self.permalink
-    if self.options.do_not_generate_spoiler_log:
-      seed_string += SEED_KEY
-    
-    self.integer_seed = self.convert_string_to_integer_md5(seed_string)
     
     self.arcs_by_path: dict[str, RARC] = {}
     self.jpcs_by_path: dict[str, JPC100] = {}
@@ -954,27 +954,22 @@ class WWRandomizer:
   def get_seed_hash(self):
     # Generate some text that will be shown on the name entry screen which has two random character names that vary based on the permalink (so the seed and settings both change it).
     # This is so two players intending to play the same seed can verify if they really are on the same seed or not.
-
+    
     if not self.permalink:
       return None
-
-    if not self.options.do_not_generate_spoiler_log:
-      integer_seed = self.convert_string_to_integer_md5(self.permalink)
-    else:
-      # When no spoiler log is generated, the seed key also affects randomization, not just the data in the permalink.
-      integer_seed = self.convert_string_to_integer_md5(self.permalink + SEED_KEY)
+    
     temp_rng = Random()
-    temp_rng.seed(integer_seed)
-
+    temp_rng.seed(self.integer_seed)
+    
     with open(os.path.join(SEEDGEN_PATH, "names.txt")) as f:
       all_names = f.read().splitlines()
     valid_names = [name for name in all_names if len(name) <= 5]
-
+    
     name_1, name_2 = temp_rng.sample(valid_names, 2)
     name_1 = tweaks.upper_first_letter(name_1)
     name_2 = tweaks.upper_first_letter(name_2)
     return name_1 + " " + name_2
-
+  
   def get_log_header(self):
     header = ""
     

--- a/randomizer.py
+++ b/randomizer.py
@@ -58,24 +58,6 @@ from randomizers.extra_starting_items import ExtraStartingItemsRandomizer
 
 from version import VERSION, VERSION_WITHOUT_COMMIT
 
-# The below are options that could be used to cheat in races.
-# They do not naturally change algorithmic item distribution, but do change the availability of information on item distribution.
-# To prevent this possibility, we change the RNG seed itself for each one of these options that is selected.
-# This ensures that item distribution is different between people with the same seed but different hints, for example.
-RNG_CHANGING_OPTIONS = [
-  "fishmen_hints",
-  "hoho_hints",
-  "korl_hints",
-  "num_path_hints",
-  "num_barren_hints",
-  "num_location_hints",
-  "num_item_hints",
-  "cryptic_hints",
-  "prioritize_remote_hints",
-  "hint_importance",
-  "do_not_generate_spoiler_log",
-]
-
 class TooFewProgressionLocationsError(Exception): pass
 class InvalidCleanISOError(Exception): pass
 class PermalinkWrongVersionError(Exception): pass
@@ -124,7 +106,7 @@ class WWRandomizer:
     if cmd_line_args.test:
       self.test_room_args = cmd_line_args.test
     
-    seed_string = self.seed
+    seed_string = self.permalink
     if self.options.do_not_generate_spoiler_log:
       seed_string += SEED_KEY
     
@@ -953,13 +935,6 @@ class WWRandomizer:
   def get_new_rng(self):
     rng = Random()
     rng.seed(self.integer_seed)
-    
-    # Further change the RNG based on which RNG-changing options are enabled
-    for i, option in enumerate(RNG_CHANGING_OPTIONS):
-      value = self.options[option]
-      for j in range(1, 100 + i):
-        rng.getrandbits(value + 20 * i + j)
-    
     return rng
   
   def weighted_choice(self, rng: Random, seq: list[T], weight_conditions: list[tuple[int, Callable[[T], bool]]]) -> T:


### PR DESCRIPTION
Previously, the randomizer's RNG was seeded with a combination of the seed name, the seed key if the spoiler log was not generated, and the `RNG_CHANGING_OPTIONS`. These options include hint options that should not naturally affect item placement, but were included to prevent cheating in races. If an option is not included in this list, it can change the permalink without affecting the randomizer's RNG. For example, if you start with a junk item like the Platform Chart or a single Heart Piece, the item placement with the same seed name will be basically identical.

This doesn't seem correct. In my opinion, two different permalinks should result in two very different seeds. As such, this PR uses the permalink, rather than the seed name for the seed string. Since all permalink-affecting options now affect the randomizer's RNG, `RNG_CHANGING_OPTIONS` is no longer necessary and is removed. I'm not sure what the motivation behind the previous approach was, or if this new approach is flawed, but it seems better and simpler.